### PR TITLE
Update tested Julia versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 using Pkg
 Pkg.add("LoopVectorization")
 ```
-LoopVectorization is supported on Julia 1.1 and later. It is tested on Julia 1.1, 1.3, and nightly.
+LoopVectorization is supported on Julia 1.1 and later. It is tested on Julia 1.5 and nightly.
 
 ## Warning
 


### PR DESCRIPTION
According to CI, the package is currently tested on the latest 1.x release (currently 1.5.4), 1.5.4 explicitly (redundant?) and nightly. However, the README.md says that Julia 1.1 and 1.3 are tested, which doesn't seem to be true. In this PR I update the corresponding line.

Feel free to edit further or close the PR if I misunderstood something.