### PR TITLE
tweak package import in file loaded by Requires

### DIFF
--- a/src/simdfunctionals/vmap_grad.jl
+++ b/src/simdfunctionals/vmap_grad.jl
@@ -1,5 +1,5 @@
 
-using VectorizationBase: AbstractSIMD
+using .VectorizationBase: AbstractSIMD
 import .ForwardDiff
 import .ChainRulesCore
 


### PR DESCRIPTION
If one bundle this package into a sysimage, it is quite easy to run into problems because the package will at Julia start time try to load `VectorizationBase` which will cause a full package lookup via the project and manifest of the currently active project. If one does not have a project active such that this is possible when Julia starts, it will error. There is actually no need for this, we can just use the VectorizationBase that is already loaded in the package.