### PR TITLE
add another assumption of at-avx to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We expect that any time you use the `@avx` macro with a given block of code that
 1. Are not indexing an array out of bounds. `@avx` does not perform any bounds checking.
 2. Are not iterating over an empty collection. Iterating over an empty loop such as `for i ∈ eachindex(Float64[])` is undefined behavior, and will likely result in the out of bounds memory accesses. Ensure that loops behave correctly.
 3. Are not relying on a specific execution order. `@avx` can and will re-order operations and loops inside its scope, so the correctness cannot depend on a particular order. You cannot implement `cumsum` with `@avx`.
+4. Are not using multiple loops at the same level in nested loops.
 
 ## Usage
 


### PR DESCRIPTION
I encountered an issue when using nested loops with multiple loops at the same level. This comment might help other users of this great package when running into such an issue. Did I understand the comment https://github.com/JuliaSIMD/LoopVectorization.jl/issues/230#issuecomment-810632972 correctly?