### PR TITLE
add Trixi to users of LoopVectorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,5 +352,6 @@ Similar approaches can be taken to make kernels working with a variety of numeri
 * [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
 * [YisyAIFramework.jl](https://github.com/SkyWorld117/YisyAIFramework.jl)
 * [TropicalGEMM.jl](https://github.com/TensorBFS/TropicalGEMM.jl)
+* [Trixi.jl](https://github.com/trixi-framework/Trixi.jl)
 
 If you're using LoopVectorization, please feel free to file a PR adding yours to the list!


### PR DESCRIPTION
We're already using LoopVectorization to get some really nice improvements in our hyperbolic PDE framework. We will use LoopVectorization even more and also other great packages of yours like CheapThreads and StrideArrays once #238 (and maybe https://github.com/JuliaSIMD/VectorizationBase.jl/issues/53) are resolved.