### PR TITLE
Pass arguments to _avx_! in registers.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.18"
+version = "0.12.19"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -20,17 +20,17 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
 ArrayInterface = "3.1.9"
-CheapThreads = "0.1.3,0.2"
+CheapThreads = "0.2"
 DocStringExtensions = "0.8"
 IfElse = "0.1"
-OffsetArrays = "1.4.1, 1.5"
+OffsetArrays = "1.4.1"
 Requires = "1"
-SLEEFPirates = "0.6.14"
+SLEEFPirates = "0.6.18"
 Static = "0.2"
 StrideArraysCore = "0.1.5"
-ThreadingUtilities = "0.4.1"
+ThreadingUtilities = "0.4.2"
 UnPack = "1"
-VectorizationBase = "0.19.36"
+VectorizationBase = "0.20.1"
 julia = "1.5"
 
 [extras]

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -3,10 +3,10 @@ module LoopVectorization
 using Static: StaticInt, gt
 using VectorizationBase, SLEEFPirates, UnPack, OffsetArrays
 using VectorizationBase: register_size, register_count, cache_linesize, cache_size, has_opmask_registers,
-    mask, pick_vector_width, MM, AbstractMask, data, grouped_strided_pointer,
-    maybestaticlength, maybestaticsize, staticm1, staticp1, staticmul, vzero,
-    maybestaticrange, offsetprecalc, lazymul,
-    maybestaticfirst, maybestaticlast, scalar_less, scalar_greaterequal, gep, gesp, NativeTypes, #llvmptr,
+  mask, pick_vector_width, MM, AbstractMask, data, grouped_strided_pointer,
+  maybestaticlength, maybestaticsize, vzero, maybestaticrange, offsetprecalc, lazymul,
+  vadd_nw, vadd_nsw, vadd_nuw, vsub_nw, vsub_nsw, vsub_nuw, vmul_nw, vmul_nsw, vmul_nuw,
+    maybestaticfirst, maybestaticlast, gep, gesp, NativeTypes, #llvmptr,
     vfmadd, vfmsub, vfnmadd, vfnmsub, vfmadd_fast, vfmsub_fast, vfnmadd_fast, vfnmsub_fast, vfmadd231, vfmsub231, vfnmadd231, vfnmsub231,
     vfma_fast, vmuladd_fast, vdiv_fast, vadd_fast, vsub_fast, vmul_fast,
     relu, stridedpointer, stridedpointer_preserve, StridedPointer, StridedBitPointer, AbstractStridedPointer, _vload, _vstore!,

--- a/src/codegen/loopstartstopmanager.jl
+++ b/src/codegen/loopstartstopmanager.jl
@@ -679,9 +679,9 @@ function pointermax_index(
             else
                 _ind = if isvectorized
                     if isone(sub)
-                        Expr(:call, lv(:vsub_fast), staticexpr(stophint), VECTORWIDTHSYMBOL)
+                        Expr(:call, lv(:vsub_nsw), staticexpr(stophint), VECTORWIDTHSYMBOL)
                     else
-                        Expr(:call, lv(:vsub_fast), staticexpr(stophint), mulexpr(VECTORWIDTHSYMBOL, sub))
+                        Expr(:call, lv(:vsub_nsw), staticexpr(stophint), mulexpr(VECTORWIDTHSYMBOL, sub))
                     end
                 else
                     staticexpr(stophint - sub)
@@ -717,9 +717,9 @@ function pointermax_index(ls::LoopSet, ar::ArrayReferenceMeta, n::Int, sub::Int,
             else
                 _ind = if isvectorized
                     if isone(sub)
-                        Expr(:call, lv(:vsub_fast), stopsym, VECTORWIDTHSYMBOL)
+                        Expr(:call, lv(:vsub_nsw), stopsym, VECTORWIDTHSYMBOL)
                     else
-                        Expr(:call, lv(:vsub_fast), stopsym, mulexpr(VECTORWIDTHSYMBOL, sub))
+                        Expr(:call, lv(:vsub_nsw), stopsym, mulexpr(VECTORWIDTHSYMBOL, sub))
                     end
                 else
                      subexpr(stopsym, sub)

--- a/src/codegen/lower_compute.jl
+++ b/src/codegen/lower_compute.jl
@@ -69,15 +69,15 @@ function _add_loopvalue!(ex::Expr, loopval::Symbol, vloop::Loop, u::Int)
         else
             mm = _MMind(loopval, step(vloop))
             if isone(u)
-                push!(ex.args, Expr(:call, lv(:vadd_fast), VECTORWIDTHSYMBOL, mm))
+                push!(ex.args, Expr(:call, lv(:vadd_nsw), VECTORWIDTHSYMBOL, mm))
             else
-                push!(ex.args, Expr(:call, lv(:vadd_fast), Expr(:call, lv(:vmul_fast), VECTORWIDTHSYMBOL, u), mm))
+                push!(ex.args, Expr(:call, lv(:vadd_nsw), Expr(:call, lv(:vmul_nsw), VECTORWIDTHSYMBOL, u), mm))
             end
         end
     elseif u == 0
         push!(ex.args, loopval)
     else
-        push!(ex.args, Expr(:call, lv(:vadd_fast), loopval, staticexpr(u)))
+        push!(ex.args, Expr(:call, lv(:vadd_nsw), loopval, staticexpr(u)))
     end
 end
 function add_loopvalue!(instrcall::Expr, loopval, ua::UnrollArgs, u₁::Int)

--- a/src/codegen/lower_threads.jl
+++ b/src/codegen/lower_threads.jl
@@ -46,7 +46,7 @@ lv_max_num_threads() = ifelse(gt(num_threads(), num_cores()), num_cores(), num_t
     end
     t
 end
-@inline cld_fast(x,y) = Base.udiv_int(vsub_fast(vadd_fast(x, y), one(y)), y)
+@inline cld_fast(x,y) = Base.udiv_int(vsub_nw(vadd_nw(x, y), one(y)), y)
 @inline function choose_num_blocks(MoW::UInt, ::StaticInt{U}, ::StaticInt{T}) where {U,T}
     factors = calc_factors(StaticInt{T}())
     for i ∈ 1:length(factors)-1
@@ -160,15 +160,15 @@ end
 #     block_per_m, blocks_per_n
 # end
 if Sys.ARCH === :x86_64
-    @inline choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = _choose_num_threads(Base.FastMath.mul_float_fast(C, 0.05460264079015985), NT, x)
+    @inline choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = _choose_num_threads(Base.mul_float_fast(C, 0.05460264079015985), NT, x)
 else
-    @inline choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = _choose_num_threads(Base.FastMath.mul_float_fast(C, 0.05460264079015985 * 0.25), NT, x)
+    @inline choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = _choose_num_threads(Base.mul_float_fast(C, 0.05460264079015985 * 0.25), NT, x)
 end
-@inline _choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = min(Base.fptoui(UInt, Base.ceil_llvm(Base.FastMath.mul_float_fast(C, Base.sqrt_llvm(Base.uitofp(Float64, x))))), NT)
+@inline _choose_num_threads(C::Float64, NT::UInt, x::Base.BitInteger) = min(Base.fptoui(UInt, Base.ceil_llvm(Base.mul_float_fast(C, Base.sqrt_llvm(Base.uitofp(Float64, x))))), NT)
 function push_loop_length_expr!(q::Expr, ls::LoopSet)
     l = 1
     ndynamic = 0
-    mulexpr = length(ls.loops) == 1 ? q : Expr(:call, lv(:vmul_fast))
+    mulexpr = length(ls.loops) == 1 ? q : Expr(:call, lv(:vmul_nw))
     for loop ∈ ls.loops
         if isstaticloop(loop)
             l *= length(loop)
@@ -177,7 +177,7 @@ function push_loop_length_expr!(q::Expr, ls::LoopSet)
             if ndynamic < 3
                 push!(mulexpr.args, loop.lensym)
             else
-                mulexpr = Expr(:call, lv(:vmul_fast), mulexpr, loop.lensym)
+                mulexpr = Expr(:call, lv(:vmul_nw), mulexpr, loop.lensym)
             end
         end
     end
@@ -191,7 +191,7 @@ function push_loop_length_expr!(q::Expr, ls::LoopSet)
         push!(mulexpr.args, l)
         push!(q.args, mulexpr)
     else
-        push!(q.args, Expr(:call, :vmul_fast, mulexpr, l))
+        push!(q.args, Expr(:call, :vmul_nw, mulexpr, l))
     end
     nothing
 end
@@ -245,7 +245,7 @@ function thread_loop_summary!(ls::LoopSet, ua::UnrollArgs, threadedloop::Loop, i
       :($num_unroll_sym = $lensym)
     else
         # :($num_unroll_sym = Base.udiv_int($lensym, $(UInt(unroll_factor))))
-      :($num_unroll_sym = Base.udiv_int(vadd_fast($lensym, $(UInt(unroll_factor-1))), $(UInt(unroll_factor))))
+      :($num_unroll_sym = Base.udiv_int(vadd_nw($lensym, $(UInt(unroll_factor-1))), $(UInt(unroll_factor))))
     end
     iterstart_sym = Symbol("#iter#start#$threadloopnumtag#")
     iterstop_sym = Symbol("#iter#stop#$threadloopnumtag#")
@@ -258,23 +258,23 @@ function thread_loop_summary!(ls::LoopSet, ua::UnrollArgs, threadedloop::Loop, i
     if isknown(step(threadedloop))
         mf = gethint(step(threadedloop))
         if isone(mf)
-            iterstop = :($iterstop_sym::Int = vadd_fast($iterstart_sym, $blksz_sym))
+            iterstop = :($iterstop_sym::Int = vadd_nsw($iterstart_sym, $blksz_sym))
             looprange = :(CloseOpen($iterstart_sym))
             lastrange = :(CloseOpen($iterstart_sym))
             push_loopbound_ends!(looprange, lastrange, unroll_factor, threadedloop, iterstop_sym, true)
         else
-            iterstop = :($iterstop_sym::Int = vadd_fast($iterstart_sym, vmul_fast($blksz_sym, $mf)))
+            iterstop = :($iterstop_sym::Int = vadd_nsw($iterstart_sym, vmul_nw($blksz_sym, $mf)))
             looprange = :($iterstart_sym:StaticInt{$mf}())
             lastrange = :($iterstart_sym:StaticInt{$mf}())
-            push_loopbound_ends!(looprange, lastrange, unroll_factor, threadedloop, :(vsub_fast($iterstop_sym,one($iterstop_sym))), false)
+            push_loopbound_ends!(looprange, lastrange, unroll_factor, threadedloop, :(vsub_nsw($iterstop_sym,one($iterstop_sym))), false)
         end
     else
         stepthread_sym = Symbol("#step#thread#$threadloopnumtag#")
         pushpreamble!(ls, :($stepthread_sym = $(getsym(step(threadedloop)))))
-        iterstop = :($iterstop_sym = vadd_fast($iterstart_sym, vmul_fast($blksz_sym, $stepthread_sym)))
+        iterstop = :($iterstop_sym = vadd_nsw($iterstart_sym, vmul_nw($blksz_sym, $stepthread_sym)))
         looprange = :($iterstart_sym:$stepthread_sym)
         lastrange = :($iterstart_sym:$stepthread_sym)
-        push_loopbound_ends!(looprange, lastrange, unroll_factor, threadedloop, :(vsub_fast($iterstop_sym,one($iterstop_sym))), false)
+        push_loopbound_ends!(looprange, lastrange, unroll_factor, threadedloop, :(vsub_nsw($iterstop_sym,one($iterstop_sym))), false)
     end
     define_len, define_num_unrolls, loopstart, iterstop, looprange, lastrange
 end
@@ -295,7 +295,7 @@ function push_loopbound_ends!(
     else
         lastsym = getsym(last(threadedloop))
         if offsetlast
-            push_last_bound!(looprange, lastrange, :(vadd_fast($lastsym, one($lastsym))), iterstop, unroll_factor)
+            push_last_bound!(looprange, lastrange, :(vadd_nsw($lastsym, one($lastsym))), iterstop, unroll_factor)
         else
             push_last_bound!(looprange, lastrange, lastsym, iterstop, unroll_factor)
         end
@@ -372,7 +372,7 @@ function thread_one_loops_expr(
     $define_len
     $define_num_unrolls
     var"#nthreads#" = Base.min(var"#nthreads#", var"#num#unrolls#thread#0#")
-    var"#nrequest#" = vsub_fast((var"#nthreads#" % UInt32), 0x00000001)
+    var"#nrequest#" = vsub_nw((var"#nthreads#" % UInt32), 0x00000001)
     $loopstart
     var"##do#thread##" = var"#nrequest#" ≠ 0x00000000
     if var"##do#thread##"
@@ -388,12 +388,12 @@ function thread_one_loops_expr(
         var"#trailzing#zeros#" = Base.trailing_zeros(var"#thread#mask#") % UInt32
         var"#nblock#size#thread#0#" = Core.ifelse(
           var"#thread#launch#count#" < (var"#nrem#thread#0#" % UInt32),
-          vadd_fast(var"#base#block#size#thread#0#", var"#block#rem#step#0#"),
+          vadd_nw(var"#base#block#size#thread#0#", var"#block#rem#step#0#"),
           var"#base#block#size#thread#0#"
         )
-        var"#trailzing#zeros#" = vadd_fast(var"#trailzing#zeros#", 0x00000001)
+        var"#trailzing#zeros#" = vadd_nw(var"#trailzing#zeros#", 0x00000001)
         $iterstop
-        var"#thread#id#" = vadd_fast(var"#thread#id#", var"#trailzing#zeros#")
+        var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
 
         avx_launch(
           Val{$UNROLL}(), $OPS, $ARF, $AM, $LPSYM,
@@ -403,7 +403,7 @@ function thread_one_loops_expr(
         var"#thread#mask#" >>>= var"#trailzing#zeros#"
 
         var"#iter#start#0#" = var"#iter#stop#0#"
-        var"#thread#launch#count#" = vadd_fast(var"#thread#launch#count#", 0x00000001)
+        var"#thread#launch#count#" = vadd_nw(var"#thread#launch#count#", 0x00000001)
         var"#threads#remain#" = var"#thread#launch#count#" ≠ var"#nrequest#"
       end
     else# eliminate undef var errors that the compiler should be able to figure out are unreachable, but doesn't
@@ -418,9 +418,9 @@ function thread_one_loops_expr(
     var"#threads#remain#" = true
     while var"#threads#remain#"
       VectorizationBase.assume(var"#thread#mask#" ≠ zero(var"#thread#mask#"))
-      var"#trailzing#zeros#" = vadd_fast(Base.trailing_zeros(var"#thread#mask#") % UInt32, 0x00000001)
+      var"#trailzing#zeros#" = vadd_nw(Base.trailing_zeros(var"#thread#mask#") % UInt32, 0x00000001)
       var"#thread#mask#" >>>= var"#trailzing#zeros#"
-      var"#thread#id#" = vadd_fast(var"#thread#id#", var"#trailzing#zeros#")
+      var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
       var"#thread#ptr#" = ThreadingUtilities.taskpointer(var"#thread#id#")
       ThreadingUtilities.wait(var"#thread#ptr#")
       $update_return_values
@@ -533,7 +533,7 @@ function thread_two_loops_expr(
     $define_len2
     $define_num_unrolls1
     $define_num_unrolls2
-    var"#unroll#prod#" = vmul_fast(var"#num#unrolls#thread#0#", var"#num#unrolls#thread#1#")
+    var"#unroll#prod#" = vmul_nw(var"#num#unrolls#thread#0#", var"#num#unrolls#thread#1#")
     if var"#nthreads#" ≥ var"#unroll#prod#"
       var"#nthreads#" = var"#unroll#prod#"
       var"#thread#factor#0#" = var"#num#unrolls#thread#0#"
@@ -553,7 +553,7 @@ function thread_two_loops_expr(
       var"#thread#factor#1#" = min(var"#thread#factor#1#", var"#num#unrolls#thread#1#")
     end
     # @show (var"#thread#factor#0#", var"#thread#factor#1#")
-    var"#nrequest#" = vsub_fast((var"#nthreads#" % UInt32), 0x00000001)
+    var"#nrequest#" = vsub_nsw((var"#nthreads#" % UInt32), 0x00000001)
     var"#loop#1#start#init#" = var"#iter#start#0#"
     var"##do#thread##" = var"#nrequest#" ≠ 0x00000000
     if var"##do#thread##"
@@ -572,18 +572,18 @@ function thread_two_loops_expr(
         var"#trailzing#zeros#" = Base.trailing_zeros(var"#thread#mask#") % UInt32
         var"#nblock#size#thread#0#" = Core.ifelse(
           var"#thread#launch#count#0#" < (var"#nrem#thread#0#" % UInt32),
-          vadd_fast(var"#base#block#size#thread#0#", var"#block#rem#step#0#"),
+          vadd_nw(var"#base#block#size#thread#0#", var"#block#rem#step#0#"),
           var"#base#block#size#thread#0#"
         )
         var"#nblock#size#thread#1#" = Core.ifelse(
           var"#thread#launch#count#1#" < (var"#nrem#thread#1#" % UInt32),
-          vadd_fast(var"#base#block#size#thread#1#", var"#block#rem#step#1#"),
+          vadd_nw(var"#base#block#size#thread#1#", var"#block#rem#step#1#"),
           var"#base#block#size#thread#1#"
         )
-        var"#trailzing#zeros#" = vadd_fast(var"#trailzing#zeros#", 0x00000001)
+        var"#trailzing#zeros#" = vadd_nw(var"#trailzing#zeros#", 0x00000001)
         $iterstop1
         $iterstop2
-        var"#thread#id#" = vadd_fast(var"#thread#id#", var"#trailzing#zeros#")
+        var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
         # @show var"#thread#id#" $loopboundexpr
         avx_launch(
           Val{$UNROLL}(), $OPS, $ARF, $AM, $LPSYM,
@@ -591,14 +591,14 @@ function thread_two_loops_expr(
         )
         var"#thread#mask#" >>>= var"#trailzing#zeros#"
 
-        var"##end#inner##" = var"#thread#launch#count#0#" == vsub_fast(var"#thread#factor#0#", 0x00000001)
-        var"#thread#launch#count#0#" = Core.ifelse(var"##end#inner##", 0x00000000, vadd_fast(var"#thread#launch#count#0#", 0x00000001))
+        var"##end#inner##" = var"#thread#launch#count#0#" == vsub_nw(var"#thread#factor#0#", 0x00000001)
+        var"#thread#launch#count#0#" = Core.ifelse(var"##end#inner##", 0x00000000, vadd_nw(var"#thread#launch#count#0#", 0x00000001))
         var"#thread#launch#count#1#" = Core.ifelse(var"##end#inner##", var"#thread#launch#count#1#" + 0x00000001, var"#thread#launch#count#1#")
 
         var"#iter#start#0#" = Core.ifelse(var"##end#inner##", var"#loop#1#start#init#", var"#iter#stop#0#")
         var"#iter#start#1#" = Core.ifelse(var"##end#inner##", var"#iter#stop#1#", var"#iter#start#1#")
 
-        var"#thread#launch#count#" = vadd_fast(var"#thread#launch#count#", 0x00000001)
+        var"#thread#launch#count#" = vadd_nw(var"#thread#launch#count#", 0x00000001)
         var"#threads#remain#" = var"#thread#launch#count#" ≠ var"#nrequest#"
       end
     else# eliminate undef var errors that the compiler should be able to figure out are unreachable, but doesn't
@@ -615,9 +615,9 @@ function thread_two_loops_expr(
     var"#threads#remain#" = true
     while var"#threads#remain#"
       VectorizationBase.assume(var"#thread#mask#" ≠ zero(var"#thread#mask#"))
-      var"#trailzing#zeros#" = vadd_fast(Base.trailing_zeros(var"#thread#mask#") % UInt32, 0x00000001)
+      var"#trailzing#zeros#" = vadd_nw(Base.trailing_zeros(var"#thread#mask#") % UInt32, 0x00000001)
       var"#thread#mask#" >>>= var"#trailzing#zeros#"
-      var"#thread#id#" = vadd_fast(var"#thread#id#", var"#trailzing#zeros#")
+      var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
       var"#thread#ptr#" = ThreadingUtilities.taskpointer(var"#thread#id#")
       ThreadingUtilities.wait(var"#thread#ptr#")
       $update_return_values

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -45,7 +45,7 @@ function rebuild_fields(sym::Symbol, offset::Int, ::Type{T}) where {T}
   gf = GlobalRef(Core,:getfield)
   if numfields === 0
     if sizeof(T) === 0
-      return Expr(:call, T), offset
+      return Expr(:new, T), offset
     else
       ret = Expr(:call, gf, sym, (offset += 1), false)
       return ret, offset
@@ -55,7 +55,7 @@ function rebuild_fields(sym::Symbol, offset::Int, ::Type{T}) where {T}
     ret = Expr(:call, GlobalRef(VectorizationBase, :unwrap), ret)
     return ret, offset
   end
-  call = (T <: Tuple) ? Expr(:tuple) : Expr(:call, T)
+  call = (T <: Tuple) ? Expr(:tuple) : Expr(:new, T)
   for f ∈ 1:numfields
     TF = fieldtype(T, f)
     TFC = fieldcount(TF)
@@ -63,7 +63,7 @@ function rebuild_fields(sym::Symbol, offset::Int, ::Type{T}) where {T}
       arg, offset = rebuild_fields(sym, offset, TF)
       push!(call.args, arg)
     elseif sizeof(TF) === 0
-      push!(call.args, Expr(:call, TF))
+      push!(call.args, Expr(:new, TF))
     else
       push!(call.args, Expr(:call, gf, sym, (offset += 1), false))
     end

--- a/src/parse/memory_ops_common.jl
+++ b/src/parse/memory_ops_common.jl
@@ -209,18 +209,18 @@ function muladd_op!(ls::LoopSet, mlt::Int, symop::Operation, offset::Int)
     vparents = [symop]
     # vparents = [, mltop, offop]
     if mlt == -1
-        f = :(-)
+        f = :vsub_nsw
         if offset ≠ 0
             pushfirst!(vparents, add_constant!(ls, offset, sizeof(Int)))
         end
     elseif mlt == 1
         offset == 0 && return only(vparents)
         push!(vparents, add_constant!(ls, offset, sizeof(Int)))
-        f = :(+)
+        f = :vadd_nsw
     else
         push!(vparents, add_constant!(ls, mlt, sizeof(Int)))
         f = if offset == 0
-            :(*)
+            :vmul_nsw
         else            
             push!(vparents, add_constant!(ls, offset, sizeof(Int)))
             :muladd

--- a/src/reconstruct_loopset.jl
+++ b/src/reconstruct_loopset.jl
@@ -669,10 +669,11 @@ Execute an `@avx` block. The block's code is represented via the arguments:
 - `vargs...` holds the encoded pointers of all the arrays (see `VectorizationBase`'s various pointer types).
 """
 @aggressive_constprop @generated function _avx_!(
-    ::Val{var"#UNROLL#"}, ::Val{var"#OPS#"}, ::Val{var"#ARF#"}, ::Val{var"#AM#"}, ::Val{var"#LPSYM#"}, var"#lv#tuple#args#"::Tuple{var"#LB#",var"#V#"}
-) where {var"#UNROLL#", var"#OPS#", var"#ARF#", var"#AM#", var"#LPSYM#", var"#LB#", var"#V#"}
+    ::Val{var"#UNROLL#"}, ::Val{var"#OPS#"}, ::Val{var"#ARF#"}, ::Val{var"#AM#"}, ::Val{var"#LPSYM#"}, ::Val{Tuple{var"#LB#",var"#V#"}}, var"#flattened#var#arguments#"::Vararg{Any,var"#num#vargs#"}
+) where {var"#UNROLL#", var"#OPS#", var"#ARF#", var"#AM#", var"#LPSYM#", var"#LB#", var"#V#", var"#num#vargs#"}
   # 1 + 1 # Irrelevant line you can comment out/in to force recompilation...
   ls = _avx_loopset(var"#OPS#", var"#ARF#", var"#AM#", var"#LPSYM#", var"#LB#".parameters, var"#V#".parameters, var"#UNROLL#")
+  pushfirst!(ls.preamble.args, :(var"#lv#tuple#args#" = reassemble_tuple(Tuple{var"#LB#",var"#V#"}, var"#flattened#var#arguments#")))
   # return @show avx_body(ls, var"#UNROLL#")
   if last(var"#UNROLL#") > 1
     inline, u₁, u₂, isbroadcast, W, rs, rc, cls, l1, l2, l3, nt = var"#UNROLL#"

--- a/src/simdfunctionals/filter.jl
+++ b/src/simdfunctionals/filter.jl
@@ -16,13 +16,13 @@ function vfilter!(f::F, x::Vector{T}, y::AbstractArray{T}) where {F,T <: NativeT
             mask = f(vy)
             VectorizationBase.compressstore!(gep(ptr_x, VectorizationBase.lazymul(st, j)), vy, mask)
             ptr_y = gep(ptr_y, incr)
-            j = vadd_fast(j, count_ones(mask))
+            j = vadd_nw(j, count_ones(mask))
         end
         rem_mask = VectorizationBase.mask(T, Nrem)
         vy = VectorizationBase.__vload(ptr_y, zero_index, rem_mask, False(), register_size())
         mask = rem_mask & f(vy)
         VectorizationBase.compressstore!(gep(ptr_x, VectorizationBase.lazymul(st, j)), vy, mask)
-        j = vadd_fast(j, count_ones(mask))
+        j = vadd_nw(j, count_ones(mask))
         Base._deleteend!(x, N-j) # resize!(x, j)
     end
     x

--- a/src/simdfunctionals/map.jl
+++ b/src/simdfunctionals/map.jl
@@ -69,7 +69,7 @@ function vmap_singlethread!(
     st = VectorizationBase.static_sizeof(T)
     UNROLL = 4
     LOG2UNROLL = 2
-    while i < N - ((W << LOG2UNROLL) - 1)
+    while i < vsub_nsw(N, ((W << LOG2UNROLL) - 1))
         index = VectorizationBase.Unroll{1,W,UNROLL,1,W,0x0000000000000000}((i,))
         v = f(VectorizationBase.fmap(vload, ptrargs, index)...)
         if NonTemporal
@@ -77,24 +77,24 @@ function vmap_singlethread!(
         else
             _vstore!(ptry, v, index, False(), True(), False(), register_size())
         end
-        i = vadd_fast(i, StaticInt{UNROLL}() * W)
+        i = vadd_nw(i, StaticInt{UNROLL}() * W)
     end
     # if Base.libllvm_version ≥ v"11" # this seems to be slower
-    #     Nm1 = vsub_fast(N, 1)
+    #     Nm1 = vsub_nw(N, 1)
     #     while i < N # stops at 16 when
     #         m = mask(V, i, Nm1)
     #         vnoaliasstore!(ptry, f(vload.(ptrargs, ((MM{W}(i),),), m)...), (MM{W}(i,),), m)
-    #         i = vadd_fast(i, W)
+    #         i = vadd_nw(i, W)
     #     end
     # else
-    while i < N - (W - 1) # stops at 16 when
+    while i < vsub_nsw(N, (W - 1)) # stops at 16 when
         vᵣ = f(map1(vload, ptrargs, (MM{W}(i),))...)
         if NonTemporal
             _vstore!(ptry, vᵣ, (MM{W}(i),), True(), True(), True(), register_size())
         else
             _vstore!(ptry, vᵣ, (MM{W}(i),), False(), True(), False(), register_size())
         end
-        i = vadd_fast(i, W)
+        i = vadd_nw(i, W)
     end
     if i < N
       m = mask(T, N & (W - 1))

--- a/src/simdfunctionals/vmap_grad.jl
+++ b/src/simdfunctionals/vmap_grad.jl
@@ -103,16 +103,16 @@ function ∂vmap_singlethread!(
     W = Int(V)
     st = VectorizationBase.static_sizeof(T)
     zero_index = MM{W}(StaticInt(0), st)
-    while i < N - ((W << 2) - 1)
+    while i < vsub_nsw(N, ((W << 2) - 1))
         index = VectorizationBase.Unroll{1,W,4,1,W,0x0000000000000000}((i,))
         v = f(init_dual(vload.(ptrargs, index))...)
         dual_store!(ptr∂y, ptry, v, index)
-        i = vadd_fast(i, 4W)
+        i = vadd_nw(i, 4W)
     end
-    while i < N - (W - 1) 
+    while i < vsub_nsw(N, (W - 1))
         vᵣ = f(init_dual(vload.(ptrargs, ((MM{W}(i),),)))...)
         dual_store!(ptr∂y, ptry, vᵣ, (MM{W}(i),))
-        i = vadd_fast(i, W)
+        i = vadd_nw(i, W)
     end
     if i < N
         m = mask(T, N & (W - 1))

--- a/src/vectorizationbase_compat/contract_pass.jl
+++ b/src/vectorizationbase_compat/contract_pass.jl
@@ -72,9 +72,13 @@ function recursive_muladd_search!(call, argv, mod, cnmul::Bool = false, csub::Bo
     fun = first(argv)
     isadd = fun === :+ || fun === :add_fast || fun === :vadd || (fun == :(Base.FastMath.add_fast))::Bool
     issub = fun === :- || fun === :sub_fast || fun === :vsub || (fun == :(Base.FastMath.sub_fast))::Bool
-    if !(isadd | issub)
-        muladd_arguments!(argv, mod, fun)
-        return length(call.args) == 4, cnmul, csub
+    if isadd
+      argv[1] = :add_fast
+    elseif issub
+      argv[1] = :sub_fast
+    else
+      muladd_arguments!(argv, mod, fun)
+      return length(call.args) == 4, cnmul, csub
     end
     exargs = @view(argv[2:end])
     issub && @assert length(exargs) == 2


### PR DESCRIPTION
On current master, they are passed in the stack.
This PR tries to pass them in registers instead.

Of course, this only matters when `_avx_!` isn't inlined.