### PR TITLE
Optimize `solve_unroll_lagrange`

### DIFF
--- a/src/modeling/determinestrategy.jl
+++ b/src/modeling/determinestrategy.jl
@@ -393,7 +393,7 @@ function determine_unroll_factor(ls::LoopSet, order::Vector{Symbol}, vloopsym::S
     UF, best_unrolled
 end
 
-function unroll_cost(X, u₁, u₂, u₁L, u₂L)
+@inline function unroll_cost(X, u₁, u₂, u₁L, u₂L)
     u₂factor = (num_iterations(u₂L, u₂)/u₂L)
     u₁factor = (num_iterations(u₁L, u₁)/u₁L)
     # X[1]*u₂factor*u₁factor + X[4] + X[2] * u₂factor + X[3] * u₁factor


### PR DESCRIPTION
```
julia> @btime LoopVectorization.solve_unroll_lagrange(view($(ls.cost_vec),:,1), view($(ls.reg_pres),:,1), 1025, 1025, 1, 1, true) #before
  330.934 ns (20 allocations: 480 bytes)
(3, 9, 1.055816625e8)

julia> @btime LoopVectorization.solve_unroll_lagrange(view($(ls.cost_vec),:,1), view($(ls.reg_pres),:,1), 1025, 1025, 1, 1, true) #after
  131.151 ns (0 allocations: 0 bytes)
(3, 9, 1.055816625e8)
```