### PR TITLE
parallel tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+# https://docs.codecov.io/docs/codecovyml-reference
+
+# There are
+#  3 [number of parts] * 3 [number of OS] = 9
+# parallel jobs in ci.yml
+codecov:
+  notify:
+    after_n_builds: 9
+comment:
+  after_n_builds: 9
+
+coverage:
+  range: 70..95
+  round: down
+  precision: 2
+
+github_checks:
+  annotations: false

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -19,7 +19,7 @@ on:
     tags: '*'
 jobs:
   test-julia-nightly:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.loopvectorization_test }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -32,6 +32,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+        loopvectorization_test:
+          - part1
+          - part2
+          - part3
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -52,6 +56,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: 4
+          LOOPVECTORIZATION_TEST: ${{ matrix.loopvectorization_test }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.loopvectorization_test }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,6 +33,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+        loopvectorization_test:
+          - part1
+          - part2
+          - part3
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -53,6 +57,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: 4
+          LOOPVECTORIZATION_TEST: ${{ matrix.loopvectorization_test }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -32,12 +32,3 @@ ThreadingUtilities = "0.4.2"
 UnPack = "1"
 VectorizationBase = "0.20.4"
 julia = "1.5"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Aqua", "InteractiveUtils", "Random", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ import InteractiveUtils, Aqua
 
 InteractiveUtils.versioninfo(stdout; verbose = true)
 
+const LOOPVECTORIZATION_TEST = get(ENV, "LOOPVECTORIZATION_TEST", "all")
 const START_TIME = time()
 
 @show LoopVectorization.register_count()
@@ -12,73 +13,79 @@ const START_TIME = time()
 
 @time @testset "LoopVectorization.jl" begin
 
-  @time Aqua.test_all(LoopVectorization)
-  # @test isempty(detect_unbound_args(LoopVectorization))
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part1"
+    @time Aqua.test_all(LoopVectorization)
+    # @test isempty(detect_unbound_args(LoopVectorization))
 
-  @time include("printmethods.jl")
+    @time include("printmethods.jl")
 
-  @time include("can_avx.jl")
+    @time include("can_avx.jl")
 
-  @time include("fallback.jl")
+    @time include("fallback.jl")
 
-  @time include("utils.jl")
+    @time include("utils.jl")
 
-  @time include("arraywrappers.jl")
+    @time include("arraywrappers.jl")
 
-  @time include("check_empty.jl")
+    @time include("check_empty.jl")
 
-  @time include("loopinductvars.jl")
+    @time include("loopinductvars.jl")
 
-  @time include("shuffleloadstores.jl")
+    @time include("shuffleloadstores.jl")
 
-  if VERSION < v"1.7-DEV"
-    @time include("zygote.jl")
-  else
-    println("Skipping Zygote tests.")
+    if VERSION < v"1.7-DEV"
+      @time include("zygote.jl")
+    else
+      println("Skipping Zygote tests.")
+    end
+
+    @time include("offsetarrays.jl")
+
+    @time include("tensors.jl")
+
+    @time include("map.jl")
+
+    @time include("filter.jl")
+
+    @time include("mapreduce.jl")
+
+    @time include("ifelsemasks.jl")
+
+    @time include("dot.jl")
+
+    @time include("special.jl")
   end
 
-  @time include("offsetarrays.jl")
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part2"
+    @time include("gemv.jl")
 
-  @time include("tensors.jl")
+    @time include("rejectunroll.jl")
 
-  @time include("map.jl")
+    @time include("miscellaneous.jl")
 
-  @time include("filter.jl")
-  
-  @time include("mapreduce.jl")
+    @time include("copy.jl")
 
-  @time include("ifelsemasks.jl")
+    @time include("broadcast.jl")
 
-  @time include("dot.jl")
+    @time include("gemm.jl")
+  end
 
-  @time include("special.jl")
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part3"
+    @time include("threading.jl")
 
-  @time include("gemv.jl")
+    @time include("tullio.jl")
 
-  @time include("rejectunroll.jl")
-  
-  @time include("miscellaneous.jl")
+    @time include("staticsize.jl")
 
-  @time include("copy.jl")
+    @time include("iteration_bound_tests.jl")
 
-  @time include("broadcast.jl")
+    @time include("outer_reductions.jl")
 
-  @time include("gemm.jl")
+    @time include("upperboundedintegers.jl")
 
-  @time include("threading.jl")
-
-  @time include("tullio.jl")
-
-  @time include("staticsize.jl")
-
-  @time include("iteration_bound_tests.jl")
-
-  @time include("outer_reductions.jl")
-  
-  @time include("upperboundedintegers.jl")
-  
-  if VERSION ≥ v"1.6"
-    @time include("quantum.jl")
+    if VERSION ≥ v"1.6"
+      @time include("quantum.jl")
+    end
   end
 end
 


### PR DESCRIPTION
I observed that the CI tests take quite a while for LoopVectorization. I guess this can be annoying since you have to wait for several hours to see whether PRs pass all tests. Here, I propose to split the tests into three parts which can be run in parallel to reduce wall clock time for CI.

If this is acceptable, the required CI tests need to be updated. 