### PR TITLE
add link to the repo to the docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,9 @@
 # LoopVectorization.jl
 
-This documentation is for `LoopVectorization.jl`.
-Please file an issue if you run into any problems.
+This documentation is for 
+[`LoopVectorization.jl`](https://github.com/JuliaSIMD/LoopVectorization.jl).
+Please [file an issue](https://github.com/JuliaSIMD/LoopVectorization.jl/issues/new) 
+if you run into any problems.
 
 ## Manual Outline
 


### PR DESCRIPTION
Sometimes, people will find the docs via Google etc. at first. Then, it canbe nice to have a link back to the repo on GitHub.