### PR TITLE
Interpret some constant expressions, fixes #305

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -39,6 +39,8 @@ jobs:
           - part4
           - part5
           - part6
+          - part7
+          - part8
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -38,6 +38,7 @@ jobs:
           - part3
           - part4
           - part5
+          - part6
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - part3
           - part4
           - part5
+          - part6
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           - part4
           - part5
           - part6
+          - part7
+          - part8
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.53"
+version = "0.12.54"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -30,5 +30,5 @@ Static = "0.2, 0.3"
 StrideArraysCore = "0.1.12"
 ThreadingUtilities = "0.4.5"
 UnPack = "1"
-VectorizationBase = "0.20.23"
+VectorizationBase = "0.20.25"
 julia = "1.5"

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -6,6 +6,7 @@ using VectorizationBase: register_size, register_count, cache_linesize, cache_si
   mask, pick_vector_width, MM, AbstractMask, data, grouped_strided_pointer, AbstractSIMD,
   vzero, offsetprecalc, lazymul,
   vadd_nw, vadd_nsw, vadd_nuw, vsub_nw, vsub_nsw, vsub_nuw, vmul_nw, vmul_nsw, vmul_nuw,
+  vfmaddsub, vfmsubadd, vpermilps177, vmovsldup, vmovshdup,
     maybestaticfirst, maybestaticlast, gep, gesp, NativeTypes, #llvmptr,
     vfmadd, vfmsub, vfnmadd, vfnmsub, vfmadd_fast, vfmsub_fast, vfnmadd_fast, vfnmsub_fast, vfmadd231, vfmsub231, vfnmadd231, vfnmsub231,
     vfma_fast, vmuladd_fast, vdiv_fast, vadd_fast, vsub_fast, vmul_fast,

--- a/src/codegen/lower_store.jl
+++ b/src/codegen/lower_store.jl
@@ -211,7 +211,7 @@ function lower_store!(
           if reductfunc === Symbol("")
             Expr(:call, lv(:_vstore!), sptrsym, gf(mvard,u), inds)
           else
-            Expr(:call, lv(:_vstore!), lv(reductfunc), sptrsym, mvaru, inds)
+            Expr(:call, lv(:_vstore!), lv(reductfunc), sptrsym, gf(mvard,u), inds)
           end
         elseif reductfunc === Symbol("")
           Expr(:call, lv(:_vstore!), sptrsym, mvar, inds)
@@ -282,13 +282,11 @@ function lower_tiled_store!(blockq::Expr, op::Operation, ls::LoopSet, ua::Unroll
         # opp = only(parents(opp))
     end
     isu₁, isu₂ = isunrolled_sym(opp, u₁loopsym, u₂loopsym, vloopsym, ls)#, u₂)
-    @assert isu₂
-    # It's reasonable forthis to be `!isu₁`
+    # It's reasonable for this to be `!isu₁`
     u = Core.ifelse(isu₁, u₁, 1)
     tup = Expr(:tuple)
     for t ∈ 0:u₂-1
-        mvar = Symbol(variable_name(opp, t), '_', u)
-        push!(tup.args, mvar)
+        push!(tup.args, Symbol(variable_name(opp, ifelse(isu₂, t, -1)), '_', u))
     end
     vut = Expr(:call, lv(:VecUnroll), tup) # `VecUnroll` of `VecUnroll`s
     inds = mem_offset_u(op, ua, inds_calc_by_ptr_offset, false, 0, ls)

--- a/src/codegen/lower_threads.jl
+++ b/src/codegen/lower_threads.jl
@@ -604,7 +604,6 @@ function thread_two_loops_expr(
             var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
             # @show var"#thread#id#" $loopboundexpr
             var"##lbvargs#to_launch##" = ($loopboundexpr, var"#vargs#")
-            @show sizeof(var"##lbvargs#to_launch##")
             avx_launch(Val{$UNROLL}(), $OPS, $ARF, $AM, $LPSYM, StaticType{typeof(var"##lbvargs#to_launch##")}(), flatten_to_tuple(var"##lbvargs#to_launch##"), var"#thread#id#")
             var"#thread#mask#" >>>= var"#trailzing#zeros#"
 
@@ -626,7 +625,6 @@ function thread_two_loops_expr(
     end
     # @show $lastboundexpr
     var"#avx#call#args#" = $avxcall_args
-    @show sizeof(var"#avx#call#args#")
     $_turbo_call_
     var"##do#thread##" || $retexpr
     # @show $retv

--- a/src/codegen/lower_threads.jl
+++ b/src/codegen/lower_threads.jl
@@ -604,6 +604,7 @@ function thread_two_loops_expr(
             var"#thread#id#" = vadd_nw(var"#thread#id#", var"#trailzing#zeros#")
             # @show var"#thread#id#" $loopboundexpr
             var"##lbvargs#to_launch##" = ($loopboundexpr, var"#vargs#")
+            @show sizeof(var"##lbvargs#to_launch##")
             avx_launch(Val{$UNROLL}(), $OPS, $ARF, $AM, $LPSYM, StaticType{typeof(var"##lbvargs#to_launch##")}(), flatten_to_tuple(var"##lbvargs#to_launch##"), var"#thread#id#")
             var"#thread#mask#" >>>= var"#trailzing#zeros#"
 
@@ -625,6 +626,7 @@ function thread_two_loops_expr(
     end
     # @show $lastboundexpr
     var"#avx#call#args#" = $avxcall_args
+    @show sizeof(var"#avx#call#args#")
     $_turbo_call_
     var"##do#thread##" || $retexpr
     # @show $retv

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -790,7 +790,7 @@ function setup_call_debug(ls::LoopSet)
   generate_call(ls, (false,zero(Int8),zero(Int8)), zero(UInt), true)
 end
 function setup_call(
-  ls::LoopSet, q::Expr, source::LineNumberNode, inline::Bool, check_empty::Bool, u₁::Int8, u₂::Int8, thread::Int, warncheckarg::Bool
+  ls::LoopSet, q::Expr, source::LineNumberNode, inline::Bool, check_empty::Bool, u₁::Int8, u₂::Int8, thread::Int, warncheckarg::Int
 )
   # We outline/inline at the macro level by creating/not creating an anonymous function.
   # The old API instead was based on inlining or not inline the generated function, but
@@ -802,7 +802,11 @@ function setup_call(
   call = generate_call(ls, (inline, u₁, u₂), thread%UInt, false)
   call = check_empty ? check_if_empty(ls, call) : call
   argfailure = make_crashy(make_fast(q))
-  warncheckarg && (argfailure = Expr(:block, :(@warn "`LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead."  maxlog=1), argfailure))
+  if warncheckarg ≠ 0
+    warning = :(@warn "`LoopVectorization.check_args` on your inputs failed; running fallback `@inbounds @fastmath` loop instead.")
+    warncheckarg > 0 && push!(warning.args, :(maxlog=$warncheckarg))
+    argfailure = Expr(:block,  warning, argfailure)
+  end
   pushprepreamble!(ls, Expr(:if, check_args_call(ls), call, argfailure))
   prepend_lnns!(ls.prepreamble, lnns)
   return ls.prepreamble

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -645,7 +645,7 @@ function generate_call_types(
   for op ∈ ops
     instr::Instruction = instruction(op)
     if (isconstant(op) && (instr == LOOPCONSTANT)) && (!roots[identifier(op)])
-      instr = op.instruction = DROPPEDCONSTANT 
+      instr = op.instruction = DROPPEDCONSTANT
     end
     push!(operation_descriptions.args, QuoteNode(instr.mod))
     push!(operation_descriptions.args, QuoteNode(instr.instr))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -257,7 +257,7 @@ end
 macro _turbo(arg, q)
   @assert q.head === :for
   q = macroexpand(__module__, q)
-  inline, check_empty, u₁, u₂ = check_macro_kwarg(arg, false, false, zero(Int8), zero(Int8), 1, false)
+  inline, check_empty, u₁, u₂ = check_macro_kwarg(arg, false, false, zero(Int8), zero(Int8), 1, 0)
   ls = LoopSet(q, __module__)
   set_hw!(ls)
   def_outer_reduct_types!(ls)

--- a/src/modeling/costs.jl
+++ b/src/modeling/costs.jl
@@ -210,6 +210,8 @@ const COST = Dict{Symbol,InstructionCost}(
     :vfmsub231 => InstructionCost(4,0.5), # - and * will fuse into this, so much of the time they're not twice as expensive
     :vfnmadd231 => InstructionCost(4,0.5), # + and -* will fuse into this, so much of the time they're not twice as expensive
     :vfnmsub231 => InstructionCost(4,0.5), # - and -* will fuse into this, so much of the time they're not twice as expensive
+    :vfmaddsub => InstructionCost(4,0.5),
+    :vfmsubadd => InstructionCost(4,0.5),
     :sqrt => InstructionCost(15,4.0,-2.0),
     :sqrt_fast => InstructionCost(15,4.0,-2.0),
     :log => InstructionCost(-3.0, 15, 30, 11),
@@ -264,7 +266,10 @@ const COST = Dict{Symbol,InstructionCost}(
     :prefetch0 => InstructionCost(0,0.0,0.0,0),
     :prefetch1 => InstructionCost(0,0.0,0.0,0),
     :prefetch2 => InstructionCost(0,0.0,0.0,0),
-    :convert => InstructionCost(4,0.5)
+  :convert => InstructionCost(4,0.5),
+  :vpermilps177 => InstructionCost(1, 1.0),
+  :vmovsldup => InstructionCost(1, 1.0),
+  :vmovshdup => InstructionCost(1, 1.0)
 )
 
 # # @inline prefetch0(x::Ptr, i) = VectorizationBase.prefetch(x, Val{3}(), Val{0}())
@@ -345,7 +350,9 @@ const REDUCTION_CLASS = Dict{Symbol,Float64}(
     :max => MAX,
     :min => MIN,
     :max_fast => MAX,
-    :min_fast => MIN
+  :min_fast => MIN,
+  :vfmaddsub => ADDITIVE_IN_REDUCTIONS,
+  :vfmsubadd => ADDITIVE_IN_REDUCTIONS
 )
 reduction_instruction_class(instr::Symbol) = get(REDUCTION_CLASS, instr, NaN)
 reduction_instruction_class(instr::Instruction) = reduction_instruction_class(instr.instr)

--- a/src/modeling/costs.jl
+++ b/src/modeling/costs.jl
@@ -113,8 +113,8 @@ vector_cost(instr::Instruction, Wshift, sizeof_T) = vector_cost(instruction_cost
 #    consolidated into a single register. The number of LICM-ed setindex!, on the other
 #    hand, should indicate how many registers we're keeping live for the sake of eventually storing.
 const COST = Dict{Symbol,InstructionCost}(
-    :getindex => InstructionCost(-3.0,0.5,3,1),
-    :conditionalload => InstructionCost(-3.0,0.5,3,1),
+    :getindex => InstructionCost(-3.0,0.5,3,0),
+    :conditionalload => InstructionCost(-3.0,0.5,3,0),
     :setindex! => InstructionCost(-3.0,1.0,3,0),
     :conditionalstore! => InstructionCost(-3.0,1.0,3,0),
     :zero => InstructionCost(1,0.5),

--- a/src/modeling/determinestrategy.jl
+++ b/src/modeling/determinestrategy.jl
@@ -1054,7 +1054,7 @@ function evaluate_cost_tile!(
     rp = opisininnerloop ? rp : zero(rp) # we only care about register pressure within the inner most loop
     rto = rt
     rt *= iters[id]
-    @show (u₁reducesrt, u₂reducesrt), (u₁reducesrp, u₂reducesrp), rto, rt, lat, rp, op
+    # @show (u₁reducesrt, u₂reducesrt), (u₁reducesrp, u₂reducesrp), rto, rt, lat, rp, op
     if isstore(op) & (!u₁reducesrt) & (!u₂reducesrt)
       irreducible_storecosts += rt
     end

--- a/src/modeling/graphs.jl
+++ b/src/modeling/graphs.jl
@@ -569,22 +569,21 @@ function fill_children!(ls::LoopSet)
   end
 end
 function cacheunrolled!(ls::LoopSet, u₁loop::Symbol, u₂loop::Symbol, vloopsym::Symbol)
-    fill_children!(ls)
-    vloop = getloop(ls, vloopsym)
-    for op ∈ operations(ls)
-        setunrolled!(ls, op, u₁loop, u₂loop, vloopsym)
-        if accesses_memory(op)
-            rc = rejectcurly(ls, op, u₁loop, vloopsym)
-            op.rejectcurly = rc
-            if rc
-                op.rejectinterleave = true
-            else
-                omop = ls.omop
-                batchid, opind = omop.batchedcollectionmap[identifier(op)]
-                op.rejectinterleave = ((batchid == 0) || (!isvectorized(op))) || rejectinterleave(ls, op, vloop, omop.batchedcollections[batchid])
-            end
-        end
+  vloop = getloop(ls, vloopsym)
+  for op ∈ operations(ls)
+    setunrolled!(ls, op, u₁loop, u₂loop, vloopsym)
+    if accesses_memory(op)
+      rc = rejectcurly(ls, op, u₁loop, vloopsym)
+      op.rejectcurly = rc
+      if rc
+        op.rejectinterleave = true
+      else
+        omop = ls.omop
+        batchid, opind = omop.batchedcollectionmap[identifier(op)]
+        op.rejectinterleave = ((batchid == 0) || (!isvectorized(op))) || rejectinterleave(ls, op, vloop, omop.batchedcollections[batchid])
+      end
     end
+  end
 end
 function setunrolled!(ls::LoopSet, op::Operation, u₁loopsym::Symbol, u₂loopsym::Symbol, vectorized::Symbol)
   u₁::Bool = u₂::Bool = v::Bool = false
@@ -1068,7 +1067,7 @@ function add_operation!(
             end
             op
         else
-            # maybe_const_compute!(ls, add_compute!(ls, LHS, RHS, elementbytes, position), elementbytes, position)
+          # maybe_const_compute!(ls, add_compute!(ls, LHS, RHS, elementbytes, position), elementbytes, position)
             add_compute!(ls, LHS, RHS, elementbytes, position)
         end
     elseif RHS.head === :if

--- a/src/modeling/graphs.jl
+++ b/src/modeling/graphs.jl
@@ -709,27 +709,66 @@ function Operation(ls::LoopSet, variable, elementbytes, instr, optype, mpref::Ar
 end
 
 operations(ls::LoopSet) = ls.operations
-function pushop!(ls::LoopSet, op::Operation, var::Symbol = name(op))
-  if iscompute(op) && length(loopdependencies(op)) == 0
-    op.node_type = constant
-    opdef = callexpr(instruction(op))
-    opparents = parents(op)
-    mangledname = Symbol('#', instruction(op).instr, '#')
-    while length(opparents) > 0
-      oppname = name(popfirst!(opparents))
-      mangledname = Symbol(mangledname, oppname, '#')
-      push!(opdef.args, oppname)
-      # if opp.instruction == LOOPCONSTANT 
-      #   push!(opdef.args, name(opp))
-      # else
 
-      # end
-    end
-    op.mangledvariable = mangledname
-    pushpreamble!(ls, Expr(:(=), name(op), opdef))
-    op.instruction = LOOPCONSTANT
-    push!(ls.preamble_symsym, (identifier(op), name(op)))
+function getconstvalues(ls::LoopSet, opparents::Vector{Operation})::Tuple{Bool,Vector{Any}}
+  vals = sizehint!(Any[], length(opparents))
+  for i ∈ eachindex(opparents)
+    pushconstvalue!(vals, ls, opparents[i]) && return true, vals
   end
+  false, vals
+end
+
+function add_constant_compute!(ls::LoopSet, op::Operation, var::Symbol)::Operation
+  op.node_type = constant
+  instr = instruction(op)
+  opparents = parents(op)
+  if Base.sym_in(instr.instr, (:add_fast,:mul_fast,:sub_fast,:div_fast,:vfmadd_fast, :vfnmadd_fast, :vfmsub_fast, :vfnmsub_fast))
+    getconstfailed, vals = getconstvalues(ls, opparents)
+    if !getconstfailed
+      f = instr.instr
+      if f === :add_fast
+        return add_constant!(ls, sum(vals), 8)::Operation
+      elseif f === :mul_fast
+        return add_constant!(ls, prod(vals), 8)::Operation
+      elseif f === :sub_fast
+        if length(opparents) == 2
+          return add_constant!(ls, vals[1] - vals[2], 8)::Operation
+        elseif length(opparents) == 1
+          return add_constant!(ls, - vals[1], 8)::Operation
+        end
+      elseif f === :div_fast
+        if length(opparents) == 2
+          return add_constant!(ls, vals[1] / vals[2], 8)::Operation
+        end
+      elseif length(opparents) == 3
+        T = typeof(sum(vals))
+        if f === :vfmadd_fast
+          return add_constant!(ls, T( (big(vals[1])*big(vals[2]) + big(vals[3]))), 8)::Operation
+        elseif f === :vfnmadd_fast
+          return add_constant!(ls, T(big(vals[3]) - big(vals[1])*big(vals[2])), 8)::Operation
+        elseif f === :vfmsub_fast
+          return add_constant!(ls, T((big(vals[1])*big(vals[2]) - big(vals[3]))), 8)::Operation
+        elseif f === :vfnmsub_fast
+          return add_constant!(ls, T(- (big(vals[1])*big(vals[2]) + big(vals[3]))), 8)::Operation
+        end
+      end
+    end
+  end
+  opdef = callexpr(instr)
+  mangledname = Symbol('#', instruction(op).instr, '#')
+  while length(opparents) > 0
+    oppname = name(popfirst!(opparents))
+    mangledname = Symbol(mangledname, oppname, '#')
+    push!(opdef.args, oppname)
+  end
+  op.mangledvariable = mangledname
+  pushpreamble!(ls, Expr(:(=), name(op), opdef))
+  op.instruction = LOOPCONSTANT
+  push!(ls.preamble_symsym, (identifier(op), name(op)))
+  _pushop!(ls, op, var)
+end
+
+function _pushop!(ls::LoopSet, op::Operation, var::Symbol)
   for opp ∈ operations(ls)
     if matches(op, opp)
       ls.opdict[var] = opp
@@ -740,6 +779,14 @@ function pushop!(ls::LoopSet, op::Operation, var::Symbol = name(op))
   ls.opdict[var] = op
   op
 end
+function pushop!(ls::LoopSet, op::Operation, var::Symbol = name(op))
+  if (iscompute(op) && length(loopdependencies(op)) == 0)
+    add_constant_compute!(ls, op, var)
+  else
+    _pushop!(ls, op, var)
+  end
+end
+
 function add_block!(ls::LoopSet, ex::Expr, elementbytes::Int, position::Int)
   for x ∈ ex.args
     x isa Expr || continue # be that general?

--- a/src/modeling/operations.jl
+++ b/src/modeling/operations.jl
@@ -264,6 +264,8 @@ function ref_for_print(op::Operation)
       else
         push!(ref.args, :($ind + $o))
       end
+    elseif s == 0
+      push!(ref.args, o)
     else
       index = :($s * $ind)
       o == 0 || (index = :($index + $o))

--- a/src/parse/add_compute.jl
+++ b/src/parse/add_compute.jl
@@ -48,29 +48,29 @@ end
 #     pushparent!(mpref.parents, mpref.loopdependencies, mpref.reduceddeps, parent)
 # end
 function add_parent!(
-    vparents::Vector{Operation}, deps::Vector{Symbol}, reduceddeps::Vector{Symbol}, ls::LoopSet, var, elementbytes::Int, position::Int
+  vparents::Vector{Operation}, deps::Vector{Symbol}, reduceddeps::Vector{Symbol}, ls::LoopSet, var, elementbytes::Int, position::Int
 )
-    parent = if var isa Symbol
-        # if var === :kern_1_1
-        #     @show operations(ls) ls.preamble_symsym
-        # end
-        opp = getop(ls, var, elementbytes)
-        # if var === :kern_1_1
-        #     @show operations(ls) ls.preamble_symsym
-        # end
-        # @show var opp first(operations(ls)) opp === first(operations(ls))
-        if iscompute(opp) && instruction(opp).instr === :identity && length(loopdependencies(opp)) < position && isone(length(parents(opp))) && name(opp) === name(first(parents(opp)))
-            first(parents(opp))
-        else
-            opp
-        end
-    elseif var isa Expr #CSE candidate
-        add_operation!(ls, gensym!(ls, "temp"), var, elementbytes, position)
-    else # assumed constant
-        add_constant!(ls, var, elementbytes)
-        # add_constant!(ls, var, deps, gensym(:loopredefconst), elementbytes)
+  parent = if var isa Symbol
+    # if var === :kern_1_1
+    #     @show operations(ls) ls.preamble_symsym
+    # end
+    opp = getop(ls, var, elementbytes)
+    # if var === :kern_1_1
+    #     @show operations(ls) ls.preamble_symsym
+    # end
+    # @show var opp first(operations(ls)) opp === first(operations(ls))
+    if iscompute(opp) && instruction(opp).instr === :identity && length(loopdependencies(opp)) < position && isone(length(parents(opp))) && name(opp) === name(first(parents(opp)))
+      first(parents(opp))
+    else
+      opp
     end
-    pushparent!(vparents, deps, reduceddeps, parent)
+  elseif var isa Expr #CSE candidate
+    add_operation!(ls, gensym!(ls, "temp"), var, elementbytes, position)
+  else # assumed constant
+    add_constant!(ls, var, elementbytes)
+    # add_constant!(ls, var, deps, gensym(:loopredefconst), elementbytes)
+  end
+  pushparent!(vparents, deps, reduceddeps, parent)
 end
 # function add_reduction!(
 #     vparents::Vector{Operation}, deps::Vector{Symbol}, reduceddeps::Vector{Symbol}, ls::LoopSet, var::Symbol, elementbytes::Int
@@ -270,7 +270,7 @@ function add_compute!(
         if var === arg
             reduction_ind = ind
             # add_reduction!(vparents, deps, reduceddeps, ls, arg, elementbytes)
-            getop(ls, arg::Symbol, elementbytes)   # weird that this needs annotation
+            getop(ls, var, elementbytes)
         elseif arg isa Expr
             isref, argref = tryrefconvert(ls, arg, elementbytes, varname(mpref))
             if isref

--- a/src/parse/add_compute.jl
+++ b/src/parse/add_compute.jl
@@ -404,7 +404,7 @@ function add_pow!(
             xo
         end
     elseif x isa Number
-        return add_constant!(ls, x ^ p, elementbytes)::Operation
+      return add_constant!(ls, x ^ p, elementbytes, var)::Operation
     end
     pint = round(Int, p)
     if p != pint

--- a/src/parse/add_compute.jl
+++ b/src/parse/add_compute.jl
@@ -404,8 +404,7 @@ function add_pow!(
             xo
         end
     elseif x isa Number
-        pushpreamble!(ls, Expr(:(=), var, x ^ p))
-        return add_constant!(ls, var, elementbytes)
+        return add_constant!(ls, x ^ p, elementbytes)::Operation
     end
     pint = round(Int, p)
     if p != pint
@@ -425,7 +424,7 @@ function add_pow!(
     elseif pint == 1
         return add_compute!(ls, var, :identity, [xop], elementbytes)
     elseif pint == 2
-        return add_compute!(ls, var, :abs2, [xop], elementbytes)
+        return add_compute!(ls, var, :abs2_fast, [xop], elementbytes)
     end
 
     # Implementation from https://github.com/JuliaLang/julia/blob/a965580ba7fd0e8314001521df254e30d686afbf/base/intfuncs.jl#L216
@@ -433,16 +432,16 @@ function add_pow!(
     pint >>= t
     while (t -= 1) > 0
         varname = (iszero(pint) && isone(t)) ? var : gensym!(ls, "pbs")
-        xop = add_compute!(ls, varname, :abs2, [xop], elementbytes)
+        xop = add_compute!(ls, varname, :abs2_fast, [xop], elementbytes)
     end
     yop = xop
     while pint > 0
         t = trailing_zeros(pint) + 1
         pint >>= t
         while (t -= 1) >= 0
-            xop = add_compute!(ls, gensym!(ls, "pbs"), :abs2, [xop], elementbytes)
+            xop = add_compute!(ls, gensym!(ls, "pbs"), :abs2_fast, [xop], elementbytes)
         end
-        yop = add_compute!(ls, iszero(pint) ? var : gensym!(ls, "pbs"), :(*), [xop, yop], elementbytes)
+        yop = add_compute!(ls, iszero(pint) ? var : gensym!(ls, "pbs"), :mul_fast, [xop, yop], elementbytes)
     end
     yop
 end

--- a/src/parse/add_constants.jl
+++ b/src/parse/add_constants.jl
@@ -124,13 +124,13 @@ end
 function add_constant!(
     ls::LoopSet, value::Symbol, deps::Vector{Symbol}, assignedsym::Symbol, elementbytes::Int, f::Symbol = Symbol("")
   )
-    retop = get(ls.opdict, value, nothing)
-    if retop === nothing
-        op = Operation(length(operations(ls)), assignedsym, elementbytes, Instruction(f, value), constant, deps, NODEPENDENCY, NOPARENTS)
-    else
-        op = Operation(length(operations(ls)), assignedsym, elementbytes, :identity, compute, deps, reduceddependencies(retop), [retop])
-    end
-    pushop!(ls, op, assignedsym)
+  retop = get(ls.opdict, value, nothing)
+  if retop === nothing
+    op = Operation(length(operations(ls)), assignedsym, elementbytes, Instruction(f, value), constant, deps, NODEPENDENCY, NOPARENTS)
+  else
+    op = Operation(length(operations(ls)), assignedsym, elementbytes, :identity, compute, deps, reduceddependencies(retop), [retop])
+  end
+  pushop!(ls, op, assignedsym)
 end
 # function add_constant!(
 #     ls::LoopSet, value, deps::Vector{Symbol}, assignedsym::Symbol, elementbytes::Int, f::Symbol = Symbol("")
@@ -142,7 +142,7 @@ end
 function add_constant!(
     ls::LoopSet, value::Number, deps::Vector{Symbol}, assignedsym::Symbol, elementbytes::Int
 )
-    op = add_constant!(ls, gensym!(ls, string(value)), deps, assignedsym, elementbytes, :numericconstant)
-    pushpreamble!(ls, op, value)
-    op
+  op = add_constant!(ls, gensym!(ls, string(value)), deps, assignedsym, elementbytes, :numericconstant)
+  pushpreamble!(ls, op, value)
+  op
 end

--- a/src/parse/add_constants.jl
+++ b/src/parse/add_constants.jl
@@ -12,33 +12,33 @@ end
 #     pushpreamble!(ls, Expr(:(=), sym, var))
 #     add_constant!(ls, sym, elementbytes)
 # end
-function add_constant!(ls::LoopSet, var::Number, elementbytes::Int = 8)
-    op = Operation(length(operations(ls)), gensym!(ls, "loopconstnumber"), elementbytes, LOOPCONSTANT, constant, NODEPENDENCY, Symbol[], NOPARENTS)
-    ops = operations(ls)
-    typ = var isa Integer ? HardInt : HardFloat
-    if iszero(var)
-        for (id,typ_) ∈ ls.preamble_zeros
-            (instruction(ops[id]) == LOOPCONSTANT && typ == typ_) && return ops[id]
-        end
-        push!(ls.preamble_zeros, (identifier(op),typ))
-    elseif var isa Integer
-        idescript = integer_description(var)
-        for (id,descript) ∈ ls.preamble_symint
-            if (instruction(ops[id]) == LOOPCONSTANT) && (idescript == descript)
-                return ops[id]
-            end
-        end
-        push!(ls.preamble_symint, (identifier(op), idescript))
-    else#if var isa FloatX
-        for (id,fvar) ∈ ls.preamble_symfloat
-            (instruction(ops[id]) == LOOPCONSTANT && fvar == var) && return ops[id]
-        end
-        push!(ls.preamble_symfloat, (identifier(op), var))
+function add_constant!(ls::LoopSet, var::Number, elementbytes::Int = 8, varname = gensym!(ls, "loopconstnumber"))
+  op = Operation(length(operations(ls)), varname, elementbytes, LOOPCONSTANT, constant, NODEPENDENCY, Symbol[], NOPARENTS)
+  ops = operations(ls)
+  typ = var isa Integer ? HardInt : HardFloat
+  if iszero(var)
+    for (id,typ_) ∈ ls.preamble_zeros
+      (instruction(ops[id]) == LOOPCONSTANT && typ == typ_) && return ops[id]
     end
-    rop = pushop!(ls, op)
-    rop === op || return rop
-    pushpreamble!(ls, Expr(:(=), name(op), var))
-    rop
+    push!(ls.preamble_zeros, (identifier(op),typ))
+  elseif var isa Integer
+    idescript = integer_description(var)
+    for (id,descript) ∈ ls.preamble_symint
+      if (instruction(ops[id]) == LOOPCONSTANT) && (idescript == descript)
+        return ops[id]
+      end
+    end
+    push!(ls.preamble_symint, (identifier(op), idescript))
+  else#if var isa FloatX
+    for (id,fvar) ∈ ls.preamble_symfloat
+      (instruction(ops[id]) == LOOPCONSTANT && fvar == var) && return ops[id]
+    end
+    push!(ls.preamble_symfloat, (identifier(op), var))
+  end
+  rop = pushop!(ls, op)
+  rop === op || return rop
+  pushpreamble!(ls, Expr(:(=), name(op), var))
+  rop
 end
 function ensure_constant_lowered!(ls::LoopSet, op::Operation)
   if iscompute(op)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -12,7 +12,7 @@ function _precompile_()
     Base.precompile(Tuple{typeof(recursive_muladd_search!),Expr,Vector{Any},Nothing,Bool,Bool})   # time: 0.029960306
     Base.precompile(Tuple{typeof(add_constant!),LoopSet,Float64,Vector{Symbol},Symbol,Int})   # time: 0.027501073
     Base.precompile(Tuple{typeof(_turbo_loopset),Any,Any,Any,Any,Core.SimpleVector,Core.SimpleVector,Tuple{Bool, Int8, Int8, Bool, Int, Int, Int, Int, Int, Int, Int, UInt}})   # time: 0.02345788
-    Base.precompile(Tuple{typeof(substitute_broadcast),Expr,Symbol,Bool,Int8,Int8,Int})   # time: 0.02281322
+    Base.precompile(Tuple{typeof(substitute_broadcast),Expr,Symbol,Bool,Int8,Int8,Int,Int})   # time: 0.02281322
     Base.precompile(Tuple{typeof(push!),LoopSet,Expr,Int,Int})   # time: 0.022659862
     Base.precompile(Tuple{typeof(add_compute!),LoopSet,Symbol,Expr,Int,Int,Nothing})   # time: 0.02167476
     Base.precompile(Tuple{typeof(checkforoffset!),LoopSet,Symbol,Int,Vector{Operation},Vector{Symbol},Vector{Int8},Vector{Int8},Vector{Bool},Vector{Symbol},Vector{Symbol},Expr})   # time: 0.020454278
@@ -105,7 +105,7 @@ function _precompile_()
     Base.precompile(Tuple{typeof(gespf1),StridedPointer{Float32, 2, -1, 0, (2, 3), Tuple{Int, Int}, Tuple{StaticInt{1}, StaticInt{0}}},Tuple{StaticInt{1}, StaticInt{1}}})   # time: 0.003363417
     Base.precompile(Tuple{typeof(repeated_index!),LoopSet,Vector{Symbol},Symbol,Int,Int})   # time: 0.003356449
     Base.precompile(Tuple{typeof(gespf1),StridedPointer{Float32, 2, 2, 0, (2, 1), Tuple{StaticInt{292}, StaticInt{4}}, Tuple{StaticInt{0}, StaticInt{0}}},Tuple{StaticInt{0}, StaticInt{0}}})   # time: 0.003346945
-    Base.precompile(Tuple{typeof(pushgespind!),Expr,LoopSet,Symbol,Int,Symbol,Bool,Bool,Bool})   # time: 0.003310727
+    Base.precompile(Tuple{typeof(pushgespind!),Expr, LoopSet, Symbol, Int, Int, Symbol, Bool, Bool, Bool})   # time: 0.003310727
     Base.precompile(Tuple{typeof(maybeaddref!),LoopSet,Operation})   # time: 0.003291367
     Base.precompile(Tuple{typeof(gespf1),StridedPointer{Float64, 3, 1, 0, (1, 2, 3), Tuple{StaticInt{8}, StaticInt{16}, Int}, Tuple{StaticInt{1}, StaticInt{1}, StaticInt{1}}},Tuple{StaticInt{1}, StaticInt{1}, StaticInt{1}}})   # time: 0.003288427
     Base.precompile(Tuple{typeof(gespf1),StridedPointer{Float32, 2, 2, 0, (2, 1), Tuple{StaticInt{308}, StaticInt{4}}, Tuple{StaticInt{0}, StaticInt{0}}},Tuple{StaticInt{0}, StaticInt{0}}})   # time: 0.003276252

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,169 +1,183 @@
 using LoopVectorization, Test
 # T = Float32
 
-@testset "broadcast" begin
-    M, N = 37, 47
-    # M = 77;
-    for T ∈ (Float32, Float64, Int32, Int64)
-        @show T, @__LINE__
-        R = T <: Integer ? (T(-100):T(100)) : T
-        a = rand(R,99,99,99);
-        b = rand(R,99,99,1);
-        bl = LowDimArray{(true,true,false)}(b);
-        @test size(bl) == size(b)
-        @test LoopVectorization.ArrayInterface.size(bl) === (size(b,1),size(b,2),LoopVectorization.StaticInt(1))
-
-        br = reshape(b, (99,99));
-        c1 = a .+ b;
-        c2 = @turbo a .+ bl;
-        @test c1 ≈ c2
-        fill!(c2, 99999); @turbo c2 .= a .+ br;
-        @test c1 ≈ c2
-        fill!(c2, 99999); @turbo c2 .= a .+ b;
-        @test c1 ≈ c2
-        br = reshape(b, (99,1,99));
-        bl = LowDimArray{(true,false,true)}(br);
-        @test size(bl) == size(br)
-        @test LoopVectorization.ArrayInterface.size(bl) === (size(br,1),LoopVectorization.StaticInt(1),size(br,3))
-        @. c1 = a + br;
-        fill!(c2, 99999); @turbo @. c2 = a + bl;
-        @test c1 ≈ c2
-        fill!(c2, 99999); @turbo @. c2 = a + br;
-        @test c1 ≈ c2
-        br = reshape(b, (1,99,99));
-        bl = LowDimArray{(false,)}(br);
-        @test size(bl) == size(br)
-        @test LoopVectorization.ArrayInterface.size(bl) === (LoopVectorization.StaticInt(1),size(br,2),size(br,3))
-        @. c1 = a + br;
-        fill!(c2, 99999);
-        @test c1 ≈ @turbo @. c2 = a + bl
-        # @test c1 ≈ c2
-        br = reshape(rand(R,99), (1,99,1));
-        bl = LowDimArray{(false,)}(br);
-        @test size(bl) == size(br)
-        @. c1 = a + br;
-        fill!(c2, 99999);
-        @turbo @. c2 = a + bl;
-        @test c1 ≈ c2
-
-        if T <: Integer
-            xs = rand(-T(100):T(100), M);
-        else
-            xs = rand(T, M);
-        end
-        max_ = maximum(xs, dims=1);
-        @test (@turbo exp.(xs .- LowDimArray{(false,)}(max_))) ≈ exp.(xs .- LowDimArray{(false,)}(max_))
-        @test size(LowDimArray{(false,)}(max_)) == size(max_)
-
-        if T === Int32
-            a = rand(T(1):T(100), 73, 1);
-            @test sqrt.(Float32.(a)) ≈ @turbo sqrt.(a)
-        elseif T === Int64
-            a = rand(T(1):T(100), 73, 1);
-            @test sqrt.(a) ≈ @tturbo sqrt.(a)
-        else
-            a = rand(T, 73, 1);
-            @test sqrt.(a) ≈ @turbo sqrt.(a)
-        end
-        
-        a = rand(R, M); B = rand(R, M, N); c = rand(R, N); c′ = c';
-        d1 =       @. a + B * c′;
-        d2 = @tturbo @. a + B * c′;
-        @test d1 ≈ d2
-        
-        @.      d1 = a + B * c′;
-        @turbo @. d2 = a + B * c′;
-        @test d1 ≈ d2
-
-        d3 = a .+ B * c;
-        d4 = @turbo a .+ B *ˡ c;
-        @test d3 ≈ d4
-
-        fill!(d3, -1000.0);
-        fill!(d4, 91000.0);
-
-        d3 .= a .+ B * c;
-        @turbo d4 .= a .+ B *ˡ c;
-        @test d3 ≈ d4
-
-        fill!(d4, 91000.0);
-        @turbo @. d4 = a + B *ˡ c;
-        @test d3 ≈ d4
-
-        M, K, N = 77, 83, 57;
-        A = rand(R,M,K); B = rand(R,K,N); C = rand(R,M,N);
-        At = copy(A');
-        D1 = C .+ A * B;
-        D2 = @tturbo C .+ A .*ˡ B;
-        @test D1 ≈ D2
-        if RUN_SLOW_TESTS
-            fill!(D2, -999999); D2 = @turbo C .+ At' *ˡ B;
-            @test D1 ≈ D2
-            fill!(D2, -999999); @test A * B ≈ (@turbo @. D2 = A *ˡ B)
-            D1 .= view(C, 1, :)' .+ A * B;
-            fill!(D2, -999999);
-            @turbo D2 .= view(C, 1, :)' .+ A .*ˡ B;
-            @test D1 ≈ D2
-            C3d = rand(R,3,M,N);
-            D1 .= view(C3d, 1, :, :) .+ A * B;
-            fill!(D2, -999999);
-            @tturbo D2 .= view(C3d, 1, :, :) .+ A .*ˡ B;
-            @test D1 ≈ D2
-        end
-        D1 .= 9999;
-        @turbo D2 .= 9999;
-        @test D1 == D2
-        D1 .= -99999;
-        @tturbo D2' .= -99999;
-        @test D1 == D2
-        
-        b = rand(T,K); x = rand(R,N);
-        D1 .= C .+ A * (b .+ x');
-        @tturbo @. D2 = C + A *ˡ (b + x');
-        @test D1 ≈ D2
-        D2 = @turbo @. C + A *ˡ (b + x');
-        @test D1 ≈ D2
-        
-        if T <: Union{Float32,Float64}
-            D3 = cos.(B');
-            D4 = @turbo cos.(B');
-            @test D3 ≈ D4
-            
-            fill!(D3, -1e3); fill!(D4, 9e9);
-            Bt = transpose(B);
-            @. D3 = exp(Bt);
-            @tturbo @. D4 = exp(Bt);
-            @test D3 ≈ D4
-
-            D1 = similar(B); D2 = similar(B);
-            D1t = transpose(D1);
-            D2t = transpose(D2);
-            @. D1t = exp(Bt);
-            @turbo @. D2t = exp(Bt);
-            @test D1t ≈ D2t
-
-            fill!(D1, -1e3);
-            fill!(D2, 9e9);
-            @. D1' = exp(Bt);
-            lset = @tturbo @. D2' = exp(Bt);
-            
-            @test D1 ≈ D2
-
-            a = rand(137);
-            b1 = @turbo @. 3*a + sin(a) + sqrt(a);
-            b2 =      @. 3*a + sin(a) + sqrt(a);
-            @test b1 ≈ b2
-            three = 3; fill!(b1, -9999);
-            @tturbo @. b1 = three*a + sin(a) + sqrt(a);
-            @test b1 ≈ b2
-
-            C = rand(100,10,10);
-            D1 = C .^ 0.3;
-            D2 = @tturbo C .^ 0.3;
-            @test D1 ≈ D2
-            @. D1 = C ^ 2;
-            @turbo @. D2 = C ^ 2;
-            @test D1 ≈ D2
-        end
-    end
+macro outline(ex)
+  quote
+    (() -> begin
+       Base.@_noinline_meta
+       $(esc(ex))
+     end)()
+  end
 end
+
+function test_broadcast(::Type{T}) where {T}
+  M, N = 37, 47
+  @show T, @__LINE__
+  R = T <: Integer ? (T(-100):T(100)) : T
+  a = rand(R,99,99,99);
+  b = rand(R,99,99,1);
+  bl = LowDimArray{(true,true,false)}(b);
+  @test size(bl) == size(b)
+  @test LoopVectorization.ArrayInterface.size(bl) === (size(b,1),size(b,2),LoopVectorization.StaticInt(1))
+
+  br = reshape(b, (99,99));
+  c1 = a .+ b;
+  c2 = @outline @turbo a .+ bl;
+  @test c1 ≈ c2
+  fill!(c2, 99999); @outline @turbo c2 .= a .+ br;
+  @test c1 ≈ c2
+  fill!(c2, 99999); @outline @turbo c2 .= a .+ b;
+  @test c1 ≈ c2
+  br = reshape(b, (99,1,99));
+  bl = LowDimArray{(true,false,true)}(br);
+  @test size(bl) == size(br)
+  @test LoopVectorization.ArrayInterface.size(bl) === (size(br,1),LoopVectorization.StaticInt(1),size(br,3))
+  @. c1 = a + br;
+  fill!(c2, 99999); @outline @turbo @. c2 = a + bl;
+  @test c1 ≈ c2
+  fill!(c2, 99999); @outline @turbo @. c2 = a + br;
+  @test c1 ≈ c2
+  br = reshape(b, (1,99,99));
+  bl = LowDimArray{(false,)}(br);
+  @test size(bl) == size(br)
+  @test LoopVectorization.ArrayInterface.size(bl) === (LoopVectorization.StaticInt(1),size(br,2),size(br,3))
+  @. c1 = a + br;
+  fill!(c2, 99999);
+  @test c1 ≈ @outline @turbo @. c2 = a + bl
+  # @test c1 ≈ c2
+  br = reshape(rand(R,99), (1,99,1));
+  bl = LowDimArray{(false,)}(br);
+  @test size(bl) == size(br)
+  @. c1 = a + br;
+  fill!(c2, 99999);
+  @outline @turbo @. c2 = a + bl;
+  @test c1 ≈ c2
+
+  if T <: Integer
+    xs = rand(-T(100):T(100), M);
+  else
+    xs = rand(T, M);
+  end
+  max_ = maximum(xs, dims=1);
+  @test (@outline @turbo exp.(xs .- LowDimArray{(false,)}(max_))) ≈ exp.(xs .- LowDimArray{(false,)}(max_))
+  @test size(LowDimArray{(false,)}(max_)) == size(max_)
+
+  if T === Int32
+    a = rand(T(1):T(100), 73, 1);
+    @test sqrt.(Float32.(a)) ≈ @outline @turbo sqrt.(a)
+  elseif T === Int64
+    a = rand(T(1):T(100), 73, 1);
+    @test sqrt.(a) ≈ @outline @tturbo sqrt.(a)
+  else
+    a = rand(T, 73, 1);
+    @test sqrt.(a) ≈ @outline @turbo sqrt.(a)
+  end
+  
+  a = rand(R, M); B = rand(R, M, N); c = rand(R, N); c′ = c';
+  d1 =       @. a + B * c′;
+  d2 = @outline @tturbo @. a + B * c′;
+  @test d1 ≈ d2
+  
+  @.      d1 = a + B * c′;
+  @outline @turbo @. d2 = a + B * c′;
+  @test d1 ≈ d2
+
+  d3 = a .+ B * c;
+  d4 = @outline @turbo a .+ B *ˡ c;
+  @test d3 ≈ d4
+
+  fill!(d3, -1000.0);
+  fill!(d4, 91000.0);
+
+  d3 .= a .+ B * c;
+  @outline @turbo d4 .= a .+ B *ˡ c;
+  @test d3 ≈ d4
+
+  fill!(d4, 91000.0);
+  @outline @turbo @. d4 = a + B *ˡ c;
+  @test d3 ≈ d4
+
+  M, K, N = 77, 83, 57;
+  A = rand(R,M,K); B = rand(R,K,N); C = rand(R,M,N);
+  At = copy(A');
+  D1 = C .+ A * B;
+  D2 = @outline @tturbo C .+ A .*ˡ B;
+  @test D1 ≈ D2
+  if RUN_SLOW_TESTS
+    fill!(D2, -999999); D2 = @outline @turbo C .+ At' *ˡ B;
+    @test D1 ≈ D2
+    fill!(D2, -999999); @test A * B ≈ (@outline @turbo @. D2 = A *ˡ B)
+    D1 .= view(C, 1, :)' .+ A * B;
+    fill!(D2, -999999);
+    @outline @turbo D2 .= view(C, 1, :)' .+ A .*ˡ B;
+    @test D1 ≈ D2
+    C3d = rand(R,3,M,N);
+    D1 .= view(C3d, 1, :, :) .+ A * B;
+    fill!(D2, -999999);
+    @outline @tturbo D2 .= view(C3d, 1, :, :) .+ A .*ˡ B;
+    @test D1 ≈ D2
+  end
+  D1 .= 9999;
+  @outline @turbo D2 .= 9999;
+  @test D1 == D2
+  D1 .= -99999;
+  @outline @tturbo D2' .= -99999;
+  @test D1 == D2
+  
+  b = rand(T,K); x = rand(R,N);
+  D1 .= C .+ A * (b .+ x');
+  @outline @tturbo @. D2 = C + A *ˡ (b + x');
+  @test D1 ≈ D2
+  D2 = @outline @turbo @. C + A *ˡ (b + x');
+  @test D1 ≈ D2
+  
+  if T <: Union{Float32,Float64}
+    D3 = cos.(B');
+    D4 = @outline @turbo cos.(B');
+    @test D3 ≈ D4
+    
+    fill!(D3, -1e3); fill!(D4, 9e9);
+    Bt = transpose(B);
+    @. D3 = exp(Bt);
+    @outline @tturbo @. D4 = exp(Bt);
+    @test D3 ≈ D4
+
+    D1 = similar(B); D2 = similar(B);
+    D1t = transpose(D1);
+    D2t = transpose(D2);
+    @. D1t = exp(Bt);
+    @outline @turbo @. D2t = exp(Bt);
+    @test D1t ≈ D2t
+
+    fill!(D1, -1e3);
+    fill!(D2, 9e9);
+    @. D1' = exp(Bt);
+    lset = @outline @tturbo @. D2' = exp(Bt);
+    
+    @test D1 ≈ D2
+
+    a = rand(137);
+    b1 = @outline @turbo @. 3*a + sin(a) + sqrt(a);
+    b2 =      @. 3*a + sin(a) + sqrt(a);
+    @test b1 ≈ b2
+    three = 3; fill!(b1, -9999);
+    @outline @tturbo @. b1 = three*a + sin(a) + sqrt(a);
+    @test b1 ≈ b2
+
+    C = rand(100,10,10);
+    D1 = C .^ 0.3;
+    D2 = @outline @tturbo C .^ 0.3;
+    @test D1 ≈ D2
+    @. D1 = C ^ 2;
+    @outline @turbo @. D2 = C ^ 2;
+    @test D1 ≈ D2
+  end
+end
+
+@testset "broadcast_float" begin
+  for T ∈ (Float32, Float64, Int32, Int64)
+    @time test_broadcast(T)
+  end
+end
+
+

--- a/test/gemm.jl
+++ b/test/gemm.jl
@@ -364,7 +364,8 @@
         end
     elseif LoopVectorization.register_count() == 16
         # @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :m, :n, :m, 1, 6)
-        @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :m, :n, :m, 2, 4)
+        # @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :m, :n, :m, 2, 4)
+        @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :n, :m, :m, 3, 3)
     end
     function rank2AmulBavx!(C, Aₘ, Aₖ, B)
         @turbo for m ∈ axes(C,1), n ∈ axes(C,2)

--- a/test/gemv.jl
+++ b/test/gemv.jl
@@ -3,7 +3,7 @@ using Test
 # T = Float32
 @testset "GEMV" begin
     # Unum, Tnum = LoopVectorization.VectorizationBase.register_count() == 16 ? (3, 4) : (4, 6)
-    Unum, Tnum = LoopVectorization.VectorizationBase.register_count() == 16 ? (1, 6) : (1, 8)
+    Unum, Tnum = LoopVectorization.VectorizationBase.register_count() == 16 ? (2, 6) : (2, 8)
     gemvq = :(for i ∈ eachindex(y)
               yᵢ = 0.0
               for j ∈ eachindex(x)
@@ -13,7 +13,7 @@ using Test
               end)
     lsgemv = LoopVectorization.loopset(gemvq);
     if LoopVectorization.register_count() != 8
-        @test LoopVectorization.choose_order(lsgemv) == (Symbol[:i, :j], :j, :i, :i, Unum, Tnum)
+        @test LoopVectorization.choose_order(lsgemv) == (Symbol[:i, :j], :i, :j, :i, Unum, Tnum)
     end
     
     function mygemv!(y, A, x)
@@ -143,7 +143,7 @@ using Test
               end)
     lsgemv = LoopVectorization.loopset(gemvq);
     if LoopVectorization.register_count() != 8
-        @test LoopVectorization.choose_order(lsgemv) == ([:d1,:d2], :d2, :d1, :d2, Unum, Tnum)
+        @test LoopVectorization.choose_order(lsgemv) == ([:d1,:d2], :d1, :d2, :d2, Unum, Tnum)
     end
     function AtmulvB_avx3!(G, B,κ)
         d = size(G,1)
@@ -162,7 +162,7 @@ using Test
            end)
     lsp = LoopVectorization.loopset(pq);
     if LoopVectorization.register_count() != 8
-        @test LoopVectorization.choose_order(lsp) == ([:d1, :d2], :d2, :d1, :d2, Unum, Tnum)
+        @test LoopVectorization.choose_order(lsp) == ([:d1, :d2], :d1, :d2, :d2, Unum, Tnum)
     end
     # lsp.preamble_symsym
 

--- a/test/grouptests.jl
+++ b/test/grouptests.jl
@@ -72,8 +72,6 @@ const START_TIME = time()
 
     @time include("tullio.jl")
 
-    @time include("staticsize.jl")
-
     @time include("iteration_bound_tests.jl")
 
     @time include("outer_reductions.jl")
@@ -93,6 +91,9 @@ const START_TIME = time()
     @time include("gemm.jl")
   end
 
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part6"
+    @time include("staticsize.jl")
+  end
 end
 
 const ELAPSED_MINUTES = (time() - START_TIME)/60

--- a/test/grouptests.jl
+++ b/test/grouptests.jl
@@ -7,6 +7,10 @@ const START_TIME = time()
 @time @testset "LoopVectorization.jl" begin
 
   @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part1"
+    @time include("broadcast.jl")
+  end
+
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part2"
     @time Aqua.test_all(LoopVectorization, ambiguities = VERSION ≥ v"1.6")
     # @test isempty(detect_unbound_args(LoopVectorization))
 
@@ -32,19 +36,9 @@ const START_TIME = time()
       println("Skipping Zygote tests.")
     end
 
-    @time include("tensors.jl")
-
     @time include("map.jl")
 
     @time include("filter.jl")
-
-    @time include("mapreduce.jl")
-
-    @time include("ifelsemasks.jl")
-
-    @time include("dot.jl")
-
-    @time include("special.jl")
 
     @time include("multiassignments.jl")
 
@@ -55,19 +49,15 @@ const START_TIME = time()
     @time include("simplemisc.jl")
   end
 
-  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part2"
-    @time include("gemv.jl")
-
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part3"
     @time include("rejectunroll.jl")
 
     @time include("miscellaneous.jl")
 
     @time include("copy.jl")
-
-    @time include("broadcast.jl")
   end
 
-  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part3"
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part4"
     @time include("threading.jl")
 
     @time include("tullio.jl")
@@ -83,16 +73,30 @@ const START_TIME = time()
     end
   end
 
-  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part4"
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part5"
     @time include("offsetarrays.jl")
   end
 
-  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part5"
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part6"
     @time include("gemm.jl")
   end
 
-  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part6"
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part7"
+    @time include("tensors.jl")
+
     @time include("staticsize.jl")
+  end
+
+  @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part8"
+    @time include("ifelsemasks.jl")
+
+    @time include("gemv.jl")
+
+    @time include("dot.jl")
+
+    @time include("special.jl")
+
+    @time include("mapreduce.jl")
   end
 end
 

--- a/test/manyloopreductions.jl
+++ b/test/manyloopreductions.jl
@@ -39,11 +39,11 @@ function mismatchedreductions!(𝛥r392, 𝛥x923, 𝛥ℛ, ℛ, r392, x923, �
 end
 
 @testset "Many Loop Reductions" begin
+  @show @__LINE__
   A = rand((2:6)...);
   N = ndims(A)
   T = eltype(A)
   let dims = (3,5)
-
     sᵢ = size(A)
     sₒ = ntuple(Val(N)) do d
       ifelse(d ∈ dims, 1, sᵢ[d])

--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -9,10 +9,12 @@ using Test
               s += x[m] * A[m,n] * y[n]
               end);
     lsdot3 = LoopVectorization.loopset(dot3q);
-    # if LoopVectorization.register_count() != 8
+    if LoopVectorization.register_count() == 32
         # @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :m, :n, :m, Unum, Tnum)#&-2
-    # end
-    @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :n, Symbol("##undefined##"), :m, 4, -1)
+      @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :n, Symbol("##undefined##"), :m, 4, -1)
+    else
+      @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :n, :m, :m, 2, 6)
+    end
 
     @static if VERSION < v"1.4"
         dot3(x, A, y) = dot(x, A * y)

--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -4,14 +4,15 @@ using Test
 
 @testset "Miscellaneous" begin
 # T = Float32
-    Unum, Tnum = LoopVectorization.register_count() == 16 ? (1, 6) : (1, 8)
+    # Unum, Tnum = LoopVectorization.register_count() == 16 ? (1, 6) : (1, 8)
     dot3q = :(for m ∈ 1:M, n ∈ 1:N
               s += x[m] * A[m,n] * y[n]
               end);
     lsdot3 = LoopVectorization.loopset(dot3q);
-    if LoopVectorization.register_count() != 8
-        @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :m, :n, :m, Unum, Tnum)#&-2
-    end
+    # if LoopVectorization.register_count() != 8
+        # @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :m, :n, :m, Unum, Tnum)#&-2
+    # end
+    @test LoopVectorization.choose_order(lsdot3) == ([:n, :m], :n, Symbol("##undefined##"), :m, 4, -1)
 
     @static if VERSION < v"1.4"
         dot3(x, A, y) = dot(x, A * y)

--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -103,7 +103,7 @@ using Test
     end
 
     colsumq = :(for i ∈ 1:size(A,2), j ∈ eachindex(x)
-                x[j] += A[j,i] - 0.25
+                x[j] += A[j,i] - 1 / 4
                 end)
     lscolsum = LoopVectorization.loopset(colsumq);
     # if LoopVectorization.register_count() != 8
@@ -133,7 +133,7 @@ using Test
         @_avx for j ∈ eachindex(x)
             xⱼ = zero(eltype(x))
             for i ∈ 1:size(A,2)
-                xⱼ += A[j,i] - 0.25
+                xⱼ += A[j,i] - 1 / 4
             end
             x[j] = xⱼ
         end
@@ -196,7 +196,7 @@ using Test
     function setcolumstovectorplus100avx!(Z::AbstractArray{T}, A) where {T} 
         @turbo for i = axes(A,1), j = axes(Z,2)
             acc = zero(T)
-            acc = acc + A[i] + 100
+            acc = acc + A[i] + (26 + 74)
             Z[i, j] = acc
         end
     end
@@ -504,7 +504,7 @@ using Test
     function test_bit_shiftavx(counter)
         accu = zero(first(counter))
         @turbo for i ∈ eachindex(counter)
-            accu += counter[i] << 1
+            accu += counter[i] << (-3 * 4 + 13) 
         end
         accu
     end

--- a/test/multiassignments.jl
+++ b/test/multiassignments.jl
@@ -21,6 +21,7 @@ end
 multiassign_turbo(x) = multiassign_turbo!(similar(x, length(x)-3), x)
 
 @testset "Multiple assignments" begin
+  @show @__LINE__
   x = rand(111);
   @test multiassign(x) ≈ multiassign_turbo(x)  
 end

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -281,6 +281,7 @@ using LoopVectorization: Static
             fill!(out4, NaN); @test pparent(avxgeneric2!(out4', At', skern)')' ≈ pparent(out1)
         end      
     end
+
   function issue_295!(R, A, B)
     @turbo for j in 1:4
       for i in 0:1
@@ -293,13 +294,6 @@ using LoopVectorization: Static
   A = [i^2 for i in 1:10];
   B = [1,2,3,4];
   R = OffsetArray(zeros(Int, 2,4), 0:1, 1:4);
-  function issue_295!(R, A, B)
-    @turbo for j in 1:4
-      for i in 0:1
-        R[i, j] = A[2i + 2j] + 0 * B[j]
-      end
-    end
-    R
-  end
+  
   @test issue_295!(R, A, B) == OffsetArray([4  16  36   64; 16  36  64  100], -1, 0)
 end

--- a/test/reduction_untangling.jl
+++ b/test/reduction_untangling.jl
@@ -40,6 +40,7 @@ function not_a_reduction_noturbo!(A, B)
 end
 
 @testset "Untangle reductions" begin
+  @show @__LINE__
   N = 11
   A1 = (re = rand(N,N), im = rand(N,N))
   A2 = deepcopy(A1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ InteractiveUtils.versioninfo(stdout; verbose = true)
 const LOOPVECTORIZATION_TEST = get(ENV, "LOOPVECTORIZATION_TEST", "all")
 
 if LOOPVECTORIZATION_TEST == "all"
-  NUMGROUPS = 5
+  NUMGROUPS = 6
   processes = Vector{Base.Process}(undef, NUMGROUPS)
   paths = Vector{String}(undef, NUMGROUPS)
   ios = Vector{IOStream}(undef, NUMGROUPS)

--- a/test/shuffleloadstores.jl
+++ b/test/shuffleloadstores.jl
@@ -129,6 +129,7 @@ function cmatmul_array!(Cc::AbstractMatrix{Complex{T}}, Ac::AbstractMatrix{Compl
     C[1,m,n] = Cre
     C[2,m,n] = Cim
   end
+  return Cc
 end
 function cmatmul_array_v2!(Cc::AbstractMatrix{Complex{T}}, Ac::AbstractMatrix{Complex{T}}, Bc::AbstractMatrix{Complex{T}}) where {T}
   C = reinterpret(Float64, Cc);
@@ -143,6 +144,7 @@ function cmatmul_array_v2!(Cc::AbstractMatrix{Complex{T}}, Ac::AbstractMatrix{Co
     end
     C[m,n] = Cmn
   end
+  return Cc
 end
 
 function issue209(M, G, J, H, B, ϕ)
@@ -350,10 +352,10 @@ end
             Bc = rand(Complex{Float64}, i, i);
             Cc1 = Ac*Bc;
             Cc2 = similar(Cc1);
-            # Cc3 = similar(Cc1)
-            cmatmul_array!(Cc2, Ac, Bc)
-
-            @test Cc1 ≈ Cc2# ≈ Cc3
+            Cc3 = similar(Cc1)
+            @test Cc1 ≈ cmatmul_array!(Cc2, Ac, Bc)
+            Cc2 .= NaN
+            @test Cc1 ≈ cmatmul_array_v2!(Cc2, Ac, Bc)
         end
     end
     @show @__LINE__

--- a/test/simplemisc.jl
+++ b/test/simplemisc.jl
@@ -7,6 +7,7 @@ function lv_turbo(r::Vector{UInt64}, mask::UInt64)
 end
 
 @testset "Simple Miscellaneous" begin
+  @show @__LINE__
   r1 = rand(UInt, 239);
   mask = ~(one(eltype(r1))<<(2))
   r2 = r1 .& mask;

--- a/test/staticsize.jl
+++ b/test/staticsize.jl
@@ -31,10 +31,10 @@ function issue238_v2!(output, matrix, input)
   end
   return nothing
 end
-const MAXTESTSIXE = 8 # N^3 loop iterations, meaning N^3 different functions compiled
+const MAXTESTSIZE = 8 # N^3 loop iterations, meaning N^3 different functions compiled
 function n2testloop(output1,output2,output3,output_nonstatic0,output_nonstatic1)
   n1, n3 = size(output1)
-  for n2 ∈ 1:MAXTESTSIXE;
+  for n2 ∈ 1:MAXTESTSIZE;
     # @show n1, n2, n3
     input  = randn(n1, n2)
     matrix = randn(n3, n2)
@@ -55,7 +55,8 @@ function n2testloop(output1,output2,output3,output_nonstatic0,output_nonstatic1)
 end
 
 @testset "Statically Sized Arrays" begin
-  for n1 ∈ 1:MAXTESTSIXE, n3 ∈ 1:MAXTESTSIXE
+  @show @__LINE__
+  for n1 ∈ 1:MAXTESTSIZE, n3 ∈ 1:MAXTESTSIZE
     output1 = StrideArray(undef, StaticInt(n1), StaticInt(n3))
     output2 = StrideArray(undef, StaticInt(n1), StaticInt(n3))
     output3 = StrideArray(undef, StaticInt(n1), StaticInt(n3))


### PR DESCRIPTION
I'll add more accurate determination of register pressure in another commit, probably to this same PR. The associated issue for that is [this comment](https://julialang.zulipchat.com/#narrow/stream/137791-general/topic/Working.20with.20Complex.20Numbers.20in.20LoopVectorization/near/247055705) on Zulip.

For now, it just contains the interpretation of some constant expressions, which can sometimes drastically reduce the amount of arguments passed to `_turbo_!`.