### PR TITLE
Allow more than 256 operations in a loopset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.54"
+version = "0.12.55"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -25,7 +25,7 @@ IfElse = "0.1"
 OffsetArrays = "1.4.1"
 Polyester = "0.3"
 Requires = "1"
-SLEEFPirates = "0.6.18"
+SLEEFPirates = "0.6.23"
 Static = "0.2, 0.3"
 StrideArraysCore = "0.1.12"
 ThreadingUtilities = "0.4.5"

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -393,44 +393,44 @@ end
 @generated function vmaterialize!(
     dest::AbstractArray{T,N}, bc::BC, ::Val{Mod}, ::Val{UNROLL}
 ) where {T <: NativeTypes, N, BC <: Union{Broadcasted,Product}, Mod, UNROLL}
-    # 2+1
-    # we have an N dimensional loop.
-    # need to construct the LoopSet
-    # @show typeof(dest)
-    ls = LoopSet(Mod)
-    inline, u₁, u₂, isbroadcast, W, rs, rc, cls, l1, l2, l3, threads, warncheckarg = UNROLL
-    set_hw!(ls, rs, rc, cls, l1, l2, l3)
-    ls.isbroadcast = isbroadcast # maybe set `false` in a DiffEq-like `@..` macro
-    loopsyms = [gensym!(ls, "n") for n ∈ 1:N]
-    add_broadcast_loops!(ls, loopsyms, :dest)
-    elementbytes = sizeof(T)
-    add_broadcast!(ls, :dest, :bc, loopsyms, BC, elementbytes)
-    storeop = add_simple_store!(ls, :dest, ArrayReference(:dest, loopsyms), elementbytes)
-    doaddref!(ls, storeop)
-    resize!(ls.loop_order, num_loops(ls)) # num_loops may be greater than N, eg Product
+  # 2+1
+  # we have an N dimensional loop.
+  # need to construct the LoopSet
+  # @show typeof(dest)
+  ls = LoopSet(Mod)
+  inline, u₁, u₂, v, isbroadcast, W, rs, rc, cls, l1, l2, l3, threads, warncheckarg = UNROLL
+  set_hw!(ls, rs, rc, cls, l1, l2, l3)
+  ls.isbroadcast = isbroadcast # maybe set `false` in a DiffEq-like `@..` macro
+  loopsyms = [gensym!(ls, "n") for n ∈ 1:N]
+  add_broadcast_loops!(ls, loopsyms, :dest)
+  elementbytes = sizeof(T)
+  add_broadcast!(ls, :dest, :bc, loopsyms, BC, elementbytes)
+  storeop = add_simple_store!(ls, :dest, ArrayReference(:dest, loopsyms), elementbytes)
+  doaddref!(ls, storeop)
+  resize!(ls.loop_order, num_loops(ls)) # num_loops may be greater than N, eg Product
   # return ls
-    sc = setup_call(ls, :(Base.Broadcast.materialize!(dest, bc)), LineNumberNode(0), inline, false, u₁, u₂, threads%Int, warncheckarg)
+  sc = setup_call(ls, :(Base.Broadcast.materialize!(dest, bc)), LineNumberNode(0), inline, false, u₁, u₂, v, threads%Int, warncheckarg)
   # return sc
-    Expr(:block, Expr(:meta,:inline), sc, :dest)
+  Expr(:block, Expr(:meta,:inline), sc, :dest)
 end
 @generated function vmaterialize!(
     dest′::Union{Adjoint{T,A},Transpose{T,A}}, bc::BC, ::Val{Mod}, ::Val{UNROLL}
 ) where {T <: NativeTypes, N, A <: AbstractArray{T,N}, BC <: Union{Broadcasted,Product}, Mod, UNROLL}
-    # we have an N dimensional loop.
-    # need to construct the LoopSet
-    ls = LoopSet(Mod)
-    inline, u₁, u₂, isbroadcast, W, rs, rc, cls, l1, l2, l3, threads, warncheckarg = UNROLL
-    set_hw!(ls, rs, rc, cls, l1, l2, l3)
-    ls.isbroadcast = isbroadcast # maybe set `false` in a DiffEq-like `@..` macro
-    loopsyms = [gensym!(ls, "n") for n ∈ 1:N]
-    pushprepreamble!(ls, Expr(:(=), :dest, Expr(:call, :parent, :dest′)))
-    add_broadcast_loops!(ls, loopsyms, :dest′)
-    elementbytes = sizeof(T)
-    add_broadcast!(ls, :dest, :bc, loopsyms, BC, elementbytes)
-    storeop = add_simple_store!(ls, :dest, ArrayReference(:dest, reverse(loopsyms)), elementbytes)
-    doaddref!(ls, storeop)
-    resize!(ls.loop_order, num_loops(ls)) # num_loops may be greater than N, eg Product
-    Expr(:block, Expr(:meta,:inline), setup_call(ls, :(Base.Broadcast.materialize!(dest′, bc)), LineNumberNode(0), inline, false, u₁, u₂, threads%Int, warncheckarg), :dest′)
+  # we have an N dimensional loop.
+  # need to construct the LoopSet
+  ls = LoopSet(Mod)
+  inline, u₁, u₂, v, isbroadcast, W, rs, rc, cls, l1, l2, l3, threads, warncheckarg = UNROLL
+  set_hw!(ls, rs, rc, cls, l1, l2, l3)
+  ls.isbroadcast = isbroadcast # maybe set `false` in a DiffEq-like `@..` macro
+  loopsyms = [gensym!(ls, "n") for n ∈ 1:N]
+  pushprepreamble!(ls, Expr(:(=), :dest, Expr(:call, :parent, :dest′)))
+  add_broadcast_loops!(ls, loopsyms, :dest′)
+  elementbytes = sizeof(T)
+  add_broadcast!(ls, :dest, :bc, loopsyms, BC, elementbytes)
+  storeop = add_simple_store!(ls, :dest, ArrayReference(:dest, reverse(loopsyms)), elementbytes)
+  doaddref!(ls, storeop)
+  resize!(ls.loop_order, num_loops(ls)) # num_loops may be greater than N, eg Product
+  Expr(:block, Expr(:meta,:inline), setup_call(ls, :(Base.Broadcast.materialize!(dest′, bc)), LineNumberNode(0), inline, false, u₁, u₂, v, threads%Int, warncheckarg), :dest′)
 end
 # these are marked `@inline` so the `@turbo` itself can choose whether or not to inline.
 @generated function vmaterialize!(

--- a/src/codegen/lower_threads.jl
+++ b/src/codegen/lower_threads.jl
@@ -337,9 +337,9 @@ function scale_cost(c, looplen)
   c
 end
 function thread_one_loops_expr(
-    ls::LoopSet, ua::UnrollArgs, valid_thread_loop::Vector{Bool}, ntmax::UInt, c::Float64,
-    UNROLL::Tuple{Bool,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt}, OPS::Expr, ARF::Expr, AM::Expr, LPSYM::Expr
-  )
+  ls::LoopSet, ua::UnrollArgs, valid_thread_loop::Vector{Bool}, ntmax::UInt, c::Float64,
+  UNROLL::Tuple{Bool,Int8,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt}, OPS::Expr, ARF::Expr, AM::Expr, LPSYM::Expr
+)
   looplen = looplengthprod(ls)
   c = scale_cost(c, looplen)
   if all(isstaticloop, ls.loops)
@@ -473,9 +473,9 @@ function define_thread_blocks(threadedloop1, threadedloop2, vloop, u‚ÇÅloop, u‚Ç
   end
 end
 function thread_two_loops_expr(
-    ls::LoopSet, ua::UnrollArgs, valid_thread_loop::Vector{Bool}, ntmax::UInt, c::Float64,
-    UNROLL::Tuple{Bool,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt}, OPS::Expr, ARF::Expr, AM::Expr, LPSYM::Expr
-  )
+  ls::LoopSet, ua::UnrollArgs, valid_thread_loop::Vector{Bool}, ntmax::UInt, c::Float64,
+  UNROLL::Tuple{Bool,Int8,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt}, OPS::Expr, ARF::Expr, AM::Expr, LPSYM::Expr
+)
   looplen = looplengthprod(ls)
   # c = 0.0225 * c / looplen
   c = scale_cost(c, looplen)
@@ -677,7 +677,7 @@ function valid_thread_loops(ls::LoopSet)
   valid_thread_loop, ua, c
 end
 function avx_threads_expr(
-    ls::LoopSet, UNROLL::Tuple{Bool,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt},
+    ls::LoopSet, UNROLL::Tuple{Bool,Int8,Int8,Int8,Bool,Int,Int,Int,Int,Int,Int,Int,UInt},
     nt::UInt, OPS::Expr, ARF::Expr, AM::Expr, LPSYM::Expr
 )
     valid_thread_loop, ua, c = valid_thread_loops(ls)

--- a/test/special.jl
+++ b/test/special.jl
@@ -334,7 +334,17 @@
         end
         a
     end
-    
+
+  function sin_sum_3loop!(u, x, y, z)
+    @turbo for k in 1:length(z)
+      for j in 1:length(y)
+        for i in 1:length(x)
+          u[i, j, k] = sin(x[i]) + sin(y[j]) + sin(z[k])
+        end 
+      end 
+    end 
+  end
+
     for T ∈ (Float32, Float64)
         @show T, @__LINE__
         a = randn(T, 127);
@@ -410,6 +420,14 @@
         @test csetanh!(Y1, X, Z) ≈ csetanhavx!(Y2, X, Z)
 
         x = rand(T, 97);
-        @test transposedvectoraccessavx(x) ≈ transposedvectoraccess(x)
+      @test transposedvectoraccessavx(x) ≈ transposedvectoraccess(x)
+
+      itot = 47;
+      dx = 1. / itot;
+      x = dx*collect(0:itot-1); y = dx*collect(0:itot-1); z = dx*collect(0:itot-1);
+      u = zeros(itot+8, itot+8, itot+8);
+      uv = @view u[5:5+itot-1, 5:5+itot-1, 5:5+itot-1];
+      sin_sum_3loop!(uv, x, y, z);
+      @test uv ≈ (identity(sin.(x)) .+ identity((sin.(y))')) .+ identity(reshape(sin.(z), (1, 1, length(z))))
     end
 end


### PR DESCRIPTION
Also adds the option to choose which loop to vectorize. The primary motivation there is for cases where correctness depends on it, e.g. the hacky uses of vector operations like `vpermilps177`.

Bumps SLEEFPirates requirement, which fixes #307 
Allowing more than 256 operations should fix #305 