### PR TITLE
Delete `convert(::Type{Any}, ::UpperBoundedInteger)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.63"
+version = "0.12.64"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/reconstruct_loopset.jl
+++ b/src/reconstruct_loopset.jl
@@ -13,7 +13,6 @@ Base.promote_rule(::Type{T}, ::Type{UpperBoundedInteger{N,S}}) where {N,T<:Base.
 Base.promote_rule(::Type{UpperBoundedInteger{N,S}}, ::Type{T}) where {N,T<:Base.BitInteger,S} = promote_rule(S,T)
 Base.convert(::Type{T}, i::UpperBoundedInteger) where {T<:Number} = convert(T, i.i)
 Base.convert(::Type{UpperBoundedInteger{N,T}}, i::UpperBoundedInteger{N,T}) where {N,T<:Base.BitInteger} = i
-Base.convert(::Type{Any}, i::UpperBoundedInteger) = i
 upper_bound(_) = typemax(Int)
 upper_bound(::Type{CloseOpen{T,UpperBoundedInteger{N,S}}}) where {T,N,S} = N - 1
 
@@ -560,7 +559,7 @@ function add_array_symbols!(ls::LoopSet, arraysymbolinds::Vector{Symbol}, offset
     for as ∈ arraysymbolinds
         pushpreamble!(ls, Expr(:(=), as, extract_varg((offset+=1))))
     end
-    return offset   
+    return offset
 end
 function extract_external_functions!(ls::LoopSet, offset::Int, vargs)
     for op ∈ operations(ls)


### PR DESCRIPTION
This method isn't necessary (it just replicates the fallback),
and it triggers ~600 invalidations.

CC @ChrisRackauckas