### PR TITLE
Set timeout-minutes

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -21,6 +21,7 @@ jobs:
   test-julia-nightly:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.loopvectorization_test }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.loopvectorization_test }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Without this, GitHub Actions runs for 6 hours when nightly is ending up in some infinite loop again (like currently seems to be the case).