### PR TITLE
Add tests that mimic array-of-struct RGB

### DIFF
--- a/test/miscellaneous.jl
+++ b/test/miscellaneous.jl
@@ -1,7 +1,6 @@
 using LoopVectorization
 using LinearAlgebra
 using OffsetArrays
-using Static
 using Test
 
 if !isdefined(@__MODULE__, Symbol("@_avx"))
@@ -1260,7 +1259,7 @@ end
             dest1r = reinterpret(reshape, fT, dest1)
             dest2r = reinterpret(reshape, fT, dest2)
             for d = 1:ndims(src)
-                Rpre  = CartesianIndices((static(1):static(3), axes(dest1)[1:d-1]...));
+                Rpre  = CartesianIndices((LoopVectorization.Static(1):LoopVectorization.Static(3), axes(dest1)[1:d-1]...));
                 Rpost = CartesianIndices(axes(dest1)[d+1:end]);
                 smoothdim_kernel_tile!(    dest1r, float(zero(T)), srcr, kernel, Rpre, axes(dest1, d), Rpost);
                 smoothdim_kernel_tile_avx!(dest2r, float(zero(T)), srcr, kernel, Rpre, axes(dest2, d), Rpost);


### PR DESCRIPTION
This is the default storage in JuliaImages. This ensures that methods
based on LoopVectorization will continue to work (an insurance policy
against future changes), and also makes it easy to check performance
(manually, since CI is bad for performance tests).

Currently, the performance on the RGB does not match the "in principle" 3x the corresponding grayscale. For a 3d output image of size 11x11x11, here are the timings I'm getting for filtering along a single dimension `d`:

| d | t grayscale (μs) | t RGB (μs) | Expected based on grayscale | `@simd` only |
| - | ----------:| -----------:| -----:| ----:|
| 1 | 4.5 | 27.5 | 13.5 | 42.2 |
| 2 | 1.8 | 14.1 | 5.4 | 48.5 |
| 3 | 1.1 | 5.2 | 3.3 | 48.8 |

Not sure if it's even fixable (meaning, we should switch to struct-of-arrays representation), but I wanted to know the answer and thought it would be better to document it. Certainly, especially for `d>1` the performance gains relative to plain `@simd` (even with which LLVM fails to vectorize) are impressive.

Note that I constructed `Rpre` with a static range for its first range, hoping it would help.