### PR TITLE
fix: #395, check if loop body is a block and warp it if not

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.106"
+version = "0.12.107"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -159,7 +159,7 @@ end
 # check if the body of loop is a block, if not convert it to a block issue#395
 function check_loopbody!(q)
   if q isa Expr && q.head == :for
-    if q.args[2].head != :block
+    if Meta.isexpr(q.args[2], :block)
       q.args[2] = Expr(:block, q.args[2])
     else
       for arg in q.args[2].args

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -159,7 +159,7 @@ end
 # check if the body of loop is a block, if not convert it to a block issue#395
 function check_loopbody!(q)
   if q isa Expr && q.head == :for
-    if Meta.isexpr(q.args[2], :block)
+    if !Meta.isexpr(q.args[2], :block)
       q.args[2] = Expr(:block, q.args[2])
     else
       for arg in q.args[2].args

--- a/test/grouptests.jl
+++ b/test/grouptests.jl
@@ -8,6 +8,7 @@ const START_TIME = time()
 
   @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part1"
     @time include("broadcast.jl")
+    @time include("parsing_inputs.jl")
   end
 
   @time if LOOPVECTORIZATION_TEST == "all" || LOOPVECTORIZATION_TEST == "part2"

--- a/test/parsing_inputs.jl
+++ b/test/parsing_inputs.jl
@@ -1,0 +1,50 @@
+using LoopVectorization, Test, ArrayInterface
+
+# macros for generate loops whose body is not a block
+macro gen_loop_issue395(ex)
+  sym, ind = ex.args
+  loop_body = :(ret[$ind] = $sym[$ind])
+  loop = Expr(:for, :($ind = axes($sym, 1)), loop_body)
+  return esc(:(@avx $loop))
+end
+macro gen_single_loop(B, A)
+  loop_body = :($B[i] = $A[i])
+  loop = Expr(:for, :(i = indices(($B, $A), 1)), loop_body)
+  return esc(:(@avx $loop))
+end
+macro gen_nest_loop(C, A, B)
+  loop_body = :($C[i, j] = $A[i] * $B[j])
+  loop_head = Expr(:block, :(j = indices(($C, $B), (2, 1))), :(i = indices(($C, $A), 1)))
+  loop = Expr(:for, loop_head, loop_body)
+  return esc(:(@avx $loop))
+end
+macro gen_A_mul_B(C, A, B)
+  inner_body = :(Cji += $A[j, k] * $B[k, i])
+  inner_loop = Expr(:for, :(k = indices(($A, $B), (2, 1))), inner_body)
+  loop = :(
+    for i in indices(($C, $B), 2), j in indices(($C, $A), 1)
+      Cji = zero(eltype($C))
+      $inner_loop
+      $C[j, i] = Cji
+    end
+  )
+  return esc(:(@avx $loop))
+end
+
+@testset "check_block, #395" begin
+  A = rand(4)
+  B = rand(4)
+  C = rand(4, 4)
+  D = zeros(4)
+  E = zeros(4, 4)
+  F = zeros(4, 4)
+  ret = zeros(4)
+  @gen_single_loop D A
+  @gen_loop_issue395 B[i]
+  @gen_nest_loop E A B
+  @gen_A_mul_B F C E
+  @test D == A
+  @test ret == B
+  @test E == A * B'
+  @test F == C * E
+end

--- a/test/parsing_inputs.jl
+++ b/test/parsing_inputs.jl
@@ -5,18 +5,18 @@ macro gen_loop_issue395(ex)
   sym, ind = ex.args
   loop_body = :(ret[$ind] = $sym[$ind])
   loop = Expr(:for, :($ind = axes($sym, 1)), loop_body)
-  return esc(:(@avx $loop))
+  return esc(:(@turbo $loop))
 end
 macro gen_single_loop(B, A)
   loop_body = :($B[i] = $A[i])
   loop = Expr(:for, :(i = indices(($B, $A), 1)), loop_body)
-  return esc(:(@avx $loop))
+  return esc(:(@turbo $loop))
 end
 macro gen_nest_loop(C, A, B)
   loop_body = :($C[i, j] = $A[i] * $B[j])
   loop_head = Expr(:block, :(j = indices(($C, $B), (2, 1))), :(i = indices(($C, $A), 1)))
   loop = Expr(:for, loop_head, loop_body)
-  return esc(:(@avx $loop))
+  return esc(:(@turbo $loop))
 end
 macro gen_A_mul_B(C, A, B)
   inner_body = :(Cji += $A[j, k] * $B[k, i])
@@ -28,7 +28,7 @@ macro gen_A_mul_B(C, A, B)
       $C[j, i] = Cji
     end
   )
-  return esc(:(@avx $loop))
+  return esc(:(@turbo $loop))
 end
 
 @testset "check_block, #395" begin


### PR DESCRIPTION
There are four macros which will generate loop whose body is not a block. The `gen_loop_issue395` and `gen_A_mul_B` macro cause `StackOverflowError` in current master while the `gen_single_loop` and `gen_nest_loop` cause `LoadError: TypeError: in typeassert, expected Int64, got a value of type Static.StaticInt{1}`. I have no idea about these errors, but warp those loop body as a block that fixes all of these error.