### PR TITLE
Restore behavior (by declaring safe) of these two-arg functions

### DIFF
--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -114,6 +114,9 @@ using Base.Meta: isexpr
 using DocStringExtensions
 import LinearAlgebra # for check_args
 
+using Base:
+  unsafe_trunc
+
 using Base.FastMath:
   add_fast,
   sub_fast,

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -922,6 +922,10 @@ can_turbo(::typeof(^), ::Val{2}) = true
 can_turbo(::typeof(Base.literal_pow), ::Val{3}) = true
 can_turbo(::typeof(Base.FastMath.pow_fast), ::Val{2}) = true
 
+for f ∈ (convert, reinterpret, trunc, unsafe_trunc, round, ceil, floor)
+    @eval can_turbo(::typeof($f), ::Val{2}) = true
+end
+
 """
     check_turbo_safe(ls::LoopSet)
 


### PR DESCRIPTION
Without these dispatches, `can_turbo` will return false for the two-arg versions of `trunc`, `unsafe_trunc`, `round`, `ceil`, and `floor`, which follow the form
 
`f(::Type{T}, ::Union{Base.IEEEFloat, Base.BitInteger64}) where T<:Union{Base.IEEEFloat, Base.BitInteger64}`

These are well-supported in `VectorizationBase`; moreover, the 1-arg versions register as safe despite the recent changes. I have included `convert` and `reinterpret` in this list, as they happen to follow the same form, and are also well-supported.

I happened upon this as I [use](https://github.com/andrewjradcliffe/MarsagliaDiscreteSamplers.jl/blob/5cba2997c8101bc88529d0b9e78d59659715e084/src/generation.jl#L113-L124) `unsafe_trunc` in a Marsaglia sampling method. I had not called said method in while (approx. 1 month), but when I did, it gave the `@inbounds @fastmath ...` warning, which I traced to `can_turbo` returning `false` for the two-arg form of `unsafe_trunc`. The other functions have the same behavior -- see below.

```julia
# functions affected
julia> using Base: unsafe_trunc

julia> fs = (
           convert,                # 1-arg obviously invalid
           reinterpret,            # 1-arg obviously invalid
           trunc,
           unsafe_trunc,
           round,
           ceil,
           floor,
       );

julia> Base.promote_op.(fs, ntuple(LoopVectorization.RetVec2Int(), Val(1))...) .=== Vec{2, Int64}
(false, false, true, true, true, true, true)

julia> Base.promote_op.(fs, ntuple(LoopVectorization.RetVec2Int(), Val(2))...) .=== Union{}
(true, true, true, true, true, true, true)
```