### PR TITLE
fix some invalidations caused by FixedPointNumbers

### DIFF
--- a/src/modeling/graphs.jl
+++ b/src/modeling/graphs.jl
@@ -834,7 +834,8 @@ function add_constant_compute!(ls::LoopSet, op::Operation, var::Symbol)::Operati
     if !getconstfailed
       f = instr.instr
       if f === :add_fast
-        return add_constant!(ls, sum(vals), 8)::Operation
+        # use init explicitly to prevent invalidations
+        return add_constant!(ls, sum(vals; init = false), 8)::Operation
       elseif f === :mul_fast
         return add_constant!(ls, prod(vals), 8)::Operation
       elseif f === :sub_fast
@@ -848,7 +849,8 @@ function add_constant_compute!(ls::LoopSet, op::Operation, var::Symbol)::Operati
           return add_constant!(ls, vals[1] / vals[2], 8)::Operation
         end
       elseif length(opparents) == 3
-        T = typeof(sum(vals))
+        # use init explicitly to prevent invalidations
+        T = typeof(sum(vals; init = false))
         if f === :vfmadd_fast
           return add_constant!(
             ls,

--- a/src/parse/memory_ops_common.jl
+++ b/src/parse/memory_ops_common.jl
@@ -859,7 +859,8 @@ function array_reference_meta!(
         addconstindex!(indices, offsets, strides, loopedindex, ind)
         ninds += 1
       else
-        vptrarray = subset_vptr!(ls, vptrarray, ninds, ind, indices, loopedindex, 0)
+        # convert ind to reduce invalidations
+        vptrarray = subset_vptr!(ls, vptrarray, ninds, convert(Int, ind), indices, loopedindex, 0)
         length(indices) == 0 && push!(indices, DISCONTIGUOUS)
       end
     elseif ind isa Expr


### PR DESCRIPTION
This is based on the following code (on Julia v1.8.3):
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("FixedPointNumbers"); Pkg.develop("LoopVectorization")

julia> using SnoopCompileCore; invalidations = @snoopr(using LoopVectorization, FixedPointNumbers); using SnoopCompile

julia> length(uinvalidated(invalidations))
613

julia> trees = invalidation_trees(invalidations);

julia> trees[end]
inserting reduce_first(::typeof(Base.add_sum), x::FixedPoint) in FixedPointNumbers at ~/.julia/packages/FixedPointNumbers/HAGk2/src/FixedPointNumbers.jl:295 invalidated:
   backedges: 1: superseding reduce_first(::typeof(Base.add_sum), x) in Base at reduce.jl:402 with MethodInstance for Base.reduce_first(::typeof(Base.add_sum), ::Any) (166 children)

julia> ascend(trees[end].backedges[end])
```

With this PR, 
```julia
julia> length(uinvalidated(invalidations))
513
```

The initial number of invalidations coming from this is bigger when loading something doing more precompilation involving LoopVectorization.jl.