### PR TITLE
Use 16 bits to store an array reference index

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoopVectorization"
 uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.142"
+version = "0.12.143"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -147,17 +147,17 @@ struct OperationStruct <: AbstractLoopOperation
   parents₃::UInt128
   node_type::OperationType
   symid::UInt16
-  array::UInt8
+  array::UInt16
 end
 optype(os) = os.node_type
 
 function findmatchingarray(ls::LoopSet, mref::ArrayReferenceMeta)
-  id = 0x01
+  id = 0x0001
   for r ∈ ls.refs_aliasing_syms
     r == mref && return id
-    id += 0x01
+    id += 0x0001
   end
-  0x00
+  0x0000
 end
 filled_8byte_chunks(u::T) where {T<:Unsigned} = sizeof(T) - (leading_zeros(u) >>> 3)
 
@@ -224,7 +224,7 @@ function OperationStruct!(
   rd = reduceddeps_uint(ls, op)
   cd = childdeps_uint(ls, op)
   p0, p1, p2, p3 = parents_uint(op)
-  array = accesses_memory(op) ? findmatchingarray(ls, op.ref) : 0x00
+  array = accesses_memory(op) ? findmatchingarray(ls, op.ref) : 0x0000
   ids[identifier(op)] = id = findindoradd!(varnames, name(op))
   OperationStruct(ld, rd, cd, p0, p1, p2, p3, op.node_type, id, array)
 end

--- a/test/grouptests.jl
+++ b/test/grouptests.jl
@@ -51,6 +51,8 @@ const START_TIME = time()
 
     @time include("reduction_untangling.jl")
 
+    @time include("manyarrayrefs.jl")
+
     @time include("manyloopreductions.jl")
 
     @time include("simplemisc.jl")

--- a/test/manyarrayrefs.jl
+++ b/test/manyarrayrefs.jl
@@ -1,0 +1,23 @@
+@generated function sum_way_too_unrolled(A, ::Val{rows}, ::Val{cols}) where {rows, cols}
+    terms = :( 0 )
+    
+    for i in 1:rows
+        for j in 1:cols
+            terms = :( $terms + A[$i, $j, k] )
+        end
+    end
+
+    quote
+        sum = 0.0
+        @turbo for k in axes(A, 3)
+            sum += $terms
+        end
+        sum
+    end
+end
+
+@testset "Many Array References" begin
+    A = rand(17, 16, 10)
+
+    @test isapprox(sum_way_too_unrolled(A, Val(17), Val(16)), sum(A))
+end


### PR DESCRIPTION
This seems to work without causing any extra errors, hopefully CI bears it out.