### PR TITLE
Fix invalidations from new `==` method

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -201,13 +201,13 @@ function replace_enumerate!(q, prepreamble)
 end
 function replace_single_enumerate!(q, prepreamble, i = nothing)
   if isnothing(i) # not nest loop
-    looprange, body = q.args[1], q.args[2]
+    looprange, body = q.args[1]::Expr, q.args[2]
   else # nest loop
-    looprange, body = q.args[1].args[i], q.args[2]
+    looprange, body = q.args[1].args[i]::Expr, q.args[2]
   end
   @assert Meta.isexpr(looprange, :(=), 2)
   itersyms, r = looprange.args
-  if Meta.isexpr(r, :call, 2) && r.args[1] == :enumerate
+  if Meta.isexpr(r, :call, 2) && r.args[1] === :enumerate
     _iter = r.args[2]
     if _iter isa Symbol
       iter = _iter

--- a/src/modeling/graphs.jl
+++ b/src/modeling/graphs.jl
@@ -1277,7 +1277,7 @@ function instruction!(ls::LoopSet, x::Expr)
   end
   # if x.head ≢ :(->)
   instr = last(x.args).value
-  instr ∈ keys(COST) && return Instruction(:LoopVectorization, instr)
+  isa(instr, Symbol) && instr ∈ keys(COST) && return Instruction(:LoopVectorization, instr)
   # end
   instr = gensym!(ls, "f")
   pushprepreamble!(ls, Expr(:(=), instr, x))


### PR DESCRIPTION
```
julia> tree
inserting ==(retcode::SciMLBase.ReturnCode.T, s::Symbol) @ SciMLBase ~/.julia/packages/SciMLBase/QqtZA/src/retcodes.jl:348 invalidated:
   mt_backedges: 1: signature ==(x, y) @ Base Base.jl:127 (formerly ==(x, y) @ Base Base.jl:127) triggered MethodInstance for MacroTools.store!(::Dict{Any, Any}, ::Symbol, ::Symbol) (3 children)
                 2: signature ==(x, y) @ Base Base.jl:127 (formerly ==(x, y) @ Base Base.jl:127) triggered MethodInstance for isequal(::Any, ::Symbol) (1 children)
   backedges: 1: superseding ==(x, y) @ Base Base.jl:127 with MethodInstance for ==(::Any, ::Symbol) (224 children)
   2 mt_cache
```

The plurality of those invalidations are LoopVectorization-related.