### PR TITLE
Fix typo in README.md's "Benchmarks" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The macro assumes that loop iterations can be reordered. It also currently suppo
 
 ## Benchmarks
 
-Please see the documentation for benchmarks versus base Julia, Clang, icc, ifort, gfortran, and Eigen. If you believe any code or compiler flags can be improved, would like to submit your own benchmarks, or have Julia code using LoopVectorization that you would like to be tested for performance regressions on a semi-regular basis, please feel file an issue or PR with the code sample.
+Please see the documentation for benchmarks versus base Julia, Clang, icc, ifort, gfortran, and Eigen. If you believe any code or compiler flags can be improved, would like to submit your own benchmarks, or have Julia code using LoopVectorization that you would like to be tested for performance regressions on a semi-regular basis, please feel free to file an issue or PR with the code sample.
 
 ## Examples
 ### Dot Product


### PR DESCRIPTION
Seems like a couple of words were missing here.