### PR TITLE
Allow for singleton specialization in precompile test

### DIFF
--- a/test/precompile/precompile.jl
+++ b/test/precompile/precompile.jl
@@ -4,7 +4,8 @@ using SnoopCompileCore
 @testset "Invalidation and precompilation" begin
   invs = @snoopr using LVUser
   m = only(methods(LVUser.filter2davx))
-  mi = m.specializations[1]
+  specs = m.specializations
+  mi = isa(specs, Core.MethodInstance) ? specs : specs[1]
   @test mi ∉ invs
   A = rand(Float64, 512, 512)
   kern = [


### PR DESCRIPTION
This updates for https://github.com/JuliaLang/julia/pull/49071. I added this test, so I thought I should fix it.