### PR TITLE
Update throughput and latency cost calc for shuffling reductions

### DIFF
--- a/src/modeling/determinestrategy.jl
+++ b/src/modeling/determinestrategy.jl
@@ -402,11 +402,7 @@ function rthroughput_latency(
       if isouterreduction(ls, op) ≠ -1 || unrolled ∉ reduceddependencies(op)
         latency = max(sl, latency)
       end
-      # if unrolled ∈ loopdependencies(op)
-      #     compute_recip_throughput_u += rt
-      # else
       compute_recip_throughput += rt
-      # end
     elseif isload(op)
       lrt, _, _, shufflert =
         cost(ls, op, (unrolled, Symbol("")), vloopsym, Wshift, size_T)
@@ -502,7 +498,6 @@ function determine_unroll_factor(
   end
   # min(8, roundpow2(max(1, round(Int, latency / (rt * num_reductions) ) ))), best_unrolled
   lrtratio = latency / rt
-  @show latency, rt
   if lrtratio ≥ 7.0
     UF = 8
   else

--- a/test/gemm.jl
+++ b/test/gemm.jl
@@ -412,7 +412,7 @@
   elseif LoopVectorization.register_count() == 16
     # @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :m, :n, :m, 1, 6)
     # @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :m, :n, :m, 2, 4)
-    @test LoopVectorization.choose_order(lsr2amb) == ([:m, :n, :k], :n, :m, :m, 3, 3)
+    @test LoopVectorization.choose_order(lsr2amb) == ([:n, :m, :k], :n, :m, :m, 3, 3)
   end
   function rank2AmulBavx!(C, Aₘ, Aₖ, B)
     @turbo for m ∈ axes(C, 1), n ∈ axes(C, 2)


### PR DESCRIPTION
Also, it heuristically doubles the estimated throughput of apple-m*. This check should work regardless of whether running Mac or Linux, as long as the CPU is recognized.

@heltonmc
```julia
julia> function dot_turbo_ls(ca::AbstractVector{Complex{T}}, cb::AbstractVector{Complex{T}}) where {T}
           a = reinterpret(reshape, T, ca)
           b = reinterpret(reshape, T, cb)
           re = zero(T)
           im = zero(T)
           LoopVectorization.@turbo_debug for i ∈ axes(a, 2)
             re += a[1, i] * b[1, i] + a[2, i] * b[2, i]
             im += a[1, i] * b[2, i] - a[2, i] * b[1, i]
           end
       end
dot_turbo_ls (generic function with 1 method)

julia> T = Complex{Float64}; n = 203;

julia> xv = rand(T, n);

julia> yv = rand(T, n);

julia> ls = dot_turbo_ls(xv,yv);

julia> LoopVectorization.choose_order_cost(ls)
rt = 4.5
sl = 12
op = var"##op#307" = LoopVectorization.vfmadd_fast(var"##op#303", var"##op#304", var"##op#308")
rt = 0.5
sl = 8
op = var"##op#309" = LoopVectorization.vfmadd_fast(var"##op#303", var"##op#306", var"##op#310")
(latency, rt) = (12.0, 5.0)
([:i], :i, Symbol("##undefined##"), :i, 4, -1, 2970.3953125000003, true)
```
It'll now unroll the complex dot product by `4`, because `12 / 5 = 2.4`.
It'll round `2.4` up to the nearest power of 2, i.e. `4`.