### PR TITLE
@turbo function(;kwag) work around

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,37 @@ BenchmarkTools.Trial:
   evals/sample:     6
 ```
 
+Note: `@turbo` does not support passing of kwargs to function calls to which it is applied, e.g:
+```julia
+julia> @turbo round.(rand(10))
+
+julia> @turbo round.(rand(10); digits = 3)
+ERROR: TypeError: in typeassert, expected Expr, got a value of type GlobalRef
+```
+
+You can work around this by creating a anonymous function before applying `@turbo` as follows:
+```julia
+struct KwargCall{F,T}
+    f::F
+    x::T
+end
+@inline (f::KwargCall)(args...) = f.f(args...; f.x...)
+
+f = KwargCall(round, (digits = 3,));
+@turbo f.(rand(10))
+10-element Vector{Float64}:
+ 0.763
+ 0.409
+ 0.87
+ 0.882
+ 0.966
+ 0.998
+ 0.055
+ 0.215
+ 0.733
+ 0.851
+```
+
 </p>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -293,14 +293,7 @@ f = KwargCall(round, (digits = 3,));
 @turbo f.(rand(10))
 10-element Vector{Float64}:
  0.763
- 0.409
- 0.87
- 0.882
- 0.966
- 0.998
- 0.055
- 0.215
- 0.733
+ ⋮
  0.851
 ```
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -40,9 +40,9 @@ Aside from loops, `LoopVectorization.jl` also supports broadcasting.
 
 Note: `@turbo` does not support passing of kwargs to function calls to which it is applied, e.g:
 ```julia
-julia> @turbo round.(rand(10))
+julia> @turbo round.(rand(10));
 
-julia> @turbo round.(rand(10); digits = 3)
+julia> @turbo round.(rand(10); digits = 3);
 ERROR: TypeError: in typeassert, expected Expr, got a value of type GlobalRef
 ```
 
@@ -58,14 +58,7 @@ f = KwargCall(round, (digits = 3,));
 @turbo f.(rand(10))
 10-element Vector{Float64}:
  0.763
- 0.409
- 0.87
- 0.882
- 0.966
- 0.998
- 0.055
- 0.215
- 0.733
+ ⋮
  0.851
 ```
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -38,6 +38,38 @@ Aside from loops, `LoopVectorization.jl` also supports broadcasting.
 !!! danger
     Broadcasting an `Array` `A` when `size(A,1) == 1` is NOT SUPPORTED, unless this is known at compile time (e.g., broadcasting a transposed vector is fine). Otherwise, you will probably crash Julia.
 
+Note: `@turbo` does not support passing of kwargs to function calls to which it is applied, e.g:
+```julia
+julia> @turbo round.(rand(10))
+
+julia> @turbo round.(rand(10); digits = 3)
+ERROR: TypeError: in typeassert, expected Expr, got a value of type GlobalRef
+```
+
+You can work around this by creating a anonymous function before applying `@turbo` as follows:
+```julia
+struct KwargCall{F,T}
+    f::F
+    x::T
+end
+@inline (f::KwargCall)(args...) = f.f(args...; f.x...)
+
+f = KwargCall(round, (digits = 3,));
+@turbo f.(rand(10))
+10-element Vector{Float64}:
+ 0.763
+ 0.409
+ 0.87
+ 0.882
+ 0.966
+ 0.998
+ 0.055
+ 0.215
+ 0.733
+ 0.851
+```
+
+
 ```julia
 julia> using LoopVectorization, BenchmarkTools
 


### PR DESCRIPTION
I've added a note that @turbo can not be applied to functions that are passed kwargs and provided an example of how to work around this limitation. Notes are provided in both the `ReadMe.md` and the `getting_started.md`
