### PR TITLE
Create `vsum`

### DIFF
--- a/docs/src/vectorized_convenience_functions.md
+++ b/docs/src/vectorized_convenience_functions.md
@@ -132,4 +132,22 @@ julia> @btime mapreduce(hypot, +, $x, $y)
 96.75538300513509
 ```
 
+## vsum
+
+Vectorized version of `sum`. `vsum(f, a)` applies `f(a[i])` for `i in eachindex(a)`, then sums the results.
+
+```julia
+julia> using LoopVectorization, BenchmarkTools
+
+julia> x = rand(127);
+
+julia> @btime vsum(hypot, $x)
+  12.095 ns (0 allocations: 0 bytes)
+66.65246070098374
+
+julia> @btime sum(hypot, $x)
+  16.992 ns (0 allocations: 0 bytes)
+66.65246070098372
+```
+
 

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -245,6 +245,7 @@ loop-reordering so as to improve performance:
   - [`@turbo`](@ref): transform `for`-loops and broadcasting
   - [`vmapreduce`](@ref): vectorized version of `mapreduce`
   - [`vreduce`](@ref): vectorized version of `reduce`
+  - [`vsum`](@ref): vectorized version of `sum`
   - [`vmap`](@ref) and `vmap!`: vectorized version of `map` and `map!`
   - [`vmapnt`](@ref) and `vmapnt!`: non-temporal variants of `vmap` and `vmap!`
   - [`vmapntt`](@ref) and `vmapntt!`: threaded variants of `vmapnt` and `vmapnt!`

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -196,6 +196,7 @@ export LowDimArray,
   vfilter,
   vfilter!,
   vmapreduce,
+  vsum,
   vreduce,
   vcount
 

--- a/src/simdfunctionals/mapreduce.jl
+++ b/src/simdfunctionals/mapreduce.jl
@@ -1,3 +1,4 @@
+import VectorizationBase: vsum
 
 @inline vreduce(::typeof(+), v::VectorizationBase.AbstractSIMDVector) = vsum(v)
 @inline vreduce(::typeof(*), v::VectorizationBase.AbstractSIMDVector) = vprod(v)
@@ -106,6 +107,16 @@ end
   vreduce(op, a_0)
 end
 @inline vmapreduce(f, op, args...) = mapreduce(f, op, args...)
+
+"""
+    vsum(A::DenseArray)
+    vsum(f, A::DenseArray)
+
+Vectorized version of `sum`. Providing a function as the first argument
+will apply the function to each element of `A` before summing.
+"""
+@inline vsum(f::F, A::AbstractArray{T}) where {F,T<:NativeTypes} = vmapreduce(f, +, A)
+@inline vsum(A::AbstractArray{T}) where {T<:NativeTypes} = vsum(identity, A)
 
 length_one_axis(::Base.OneTo) = Base.OneTo(1)
 length_one_axis(::Any) = 1:1

--- a/test/mapreduce.jl
+++ b/test/mapreduce.jl
@@ -60,6 +60,9 @@
     end
     @test vmapreduce(log, +, x) ≈ sum(log, x)
     @test vmapreduce(abs2, +, x) ≈ sum(abs2, x)
+    @test vsum(log, x) ≈ sum(log, x)
+    @test vsum(abs2, x) ≈ sum(abs2, x)
+    @test vsum(x) ≈ sum(x)
     @test maximum(x) == vreduce(max, x) == maximum_avx(x)
     @test minimum(x) == vreduce(min, x) == minimum_avx(x)
 


### PR DESCRIPTION
This creates a vectorized version of `sum`, as has been done with `vmapreduce` and `vreduce` already. The implementation is just an alias:

```julia
@inline vsum(f::F, A::AbstractArray{T}) where {F,T<:NativeTypes} = vmapreduce(f, +, A)
@inline vsum(A::AbstractArray{T}) where {T<:NativeTypes} = vsum(identity, A)
```

(There is a `vsum` in VectorizationBase.jl; that one is I think (?) an internal utility, as it doesn't take normal arrays.)

For example:

```julia
julia> using LoopVectorization, BenchmarkTools

julia> x = rand(127);

julia> @btime vsum(hypot, $x)
  12.095 ns (0 allocations: 0 bytes)
66.65246070098374

julia> @btime sum(hypot, $x)
  16.992 ns (0 allocations: 0 bytes)
66.65246070098372
```