### PR TITLE
Remove ArrayInterfaceCore dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.12.165"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 CloseOpenIntervals = "fb6a15b2-703c-40df-9091-08a04967cfa9"
@@ -38,7 +37,6 @@ SpecialFunctionsExt = "SpecialFunctions"
 
 [compat]
 ArrayInterface = "7"
-ArrayInterfaceCore = "0.1.5"
 CPUSummary = "0.1.3 - 0.1.8, 0.1.11, 0.2.1"
 ChainRulesCore = "1"
 CloseOpenIntervals = "0.1.10"

--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -5,7 +5,7 @@ if isdefined(Base, :Experimental) &&
   @eval Base.Experimental.@max_methods 1
 end
 
-using ArrayInterfaceCore: UpTri, LoTri
+using ArrayInterface: UpTri, LoTri
 using Static: StaticInt, gt, static, Zero, One, reduce_tup
 using VectorizationBase,
   SLEEFPirates, UnPack, OffsetArrays, StaticArrayInterface


### PR DESCRIPTION
ArrayInterface 7.x, which is already required, switched to using package extensions and removed the ArrayInterfaceCore package.
Get rid of that dependency and use the symbols directly from ArrayInterface instead.

(These two symbols are just aliases of types from other packages which is why this still works right now.)