### PR TITLE
Separate `LoopVectorization.vsum` from `VectorizationBase.vsum`

### DIFF
--- a/src/LoopVectorization.jl
+++ b/src/LoopVectorization.jl
@@ -82,7 +82,6 @@ using VectorizationBase:
   reduced_any,
   reduce_to_all,
   reduce_to_any,
-  vsum,
   vprod,
   vmaximum,
   vminimum,

--- a/src/modeling/costs.jl
+++ b/src/modeling/costs.jl
@@ -598,7 +598,7 @@ reduce_number_of_vectors(x::Float64) =
   end
 reduction_to_scalar(x::Float64) =
   if x == ADDITIVE_IN_REDUCTIONS
-    :vsum
+    :(VectorizationBase.vsum)
   elseif x == MULTIPLICATIVE_IN_REDUCTIONS
     :vprod
   elseif x == MAX

--- a/src/simdfunctionals/mapreduce.jl
+++ b/src/simdfunctionals/mapreduce.jl
@@ -1,6 +1,5 @@
-import VectorizationBase: vsum
 
-@inline vreduce(::typeof(+), v::VectorizationBase.AbstractSIMDVector) = vsum(v)
+@inline vreduce(::typeof(+), v::VectorizationBase.AbstractSIMDVector) = VectorizationBase.vsum(v)
 @inline vreduce(::typeof(*), v::VectorizationBase.AbstractSIMDVector) = vprod(v)
 @inline vreduce(::typeof(max), v::VectorizationBase.AbstractSIMDVector) =
   vmaximum(v)


### PR DESCRIPTION
Seems like it might be better to have `LoopVectorization.vsum != VectorizationBase.vsum` esp. if we might want to extend the former (but not the latter) in other packages. I think this isn't technically breaking and hopefully it doesn't break anything if I did it right, but will see how tests look