### PR TITLE
remove debug statements

### DIFF
--- a/src/condense_loopset.jl
+++ b/src/condense_loopset.jl
@@ -938,7 +938,7 @@ end
 @inline check_args(::VectorizationBase.AbstractStridedPointer) = true
 @inline function check_args(x)
   # @info "`LoopVectorization.check_args(::$(typeof(x))) == false`, therefore compiling a probably slow `@inbounds @fastmath` fallback loop." maxlog=1
-  @show @__LINE__, typeof(x)
+  # DEBUG: @show @__LINE__, typeof(x)
   false
 end
 @inline check_args(A, B, C::Vararg{Any,K}) where {K} =
@@ -956,15 +956,15 @@ Returns true if the element type is supported.
 """
 @inline check_type(::Type{T}) where {T<:NativeTypes} = true
 @inline function check_type(::Type{T}) where {T}
-@show @__LINE__, T
-false
+  # DEBUG: @show @__LINE__, T
+  false
 end
 @inline check_type(::Type{T}) where {T<:AbstractSIMD} = true
 @inline check_device(::ArrayInterface.CPUPointer) = true
 @inline check_device(::ArrayInterface.CPUTuple) = true
 @inline function check_device(x)
-@show @__LINE__, typeof(x)
-false
+  # DEBUG: @show @__LINE__, typeof(x)
+  false
 end
 
 function check_args_call(ls::LoopSet)
@@ -985,7 +985,7 @@ can be used inside a `@turbo` loop.
 """
 function can_turbo(f::F, ::Val{NARGS})::Bool where {F,NARGS}
   promoted_op = Base.promote_op(f, ntuple(RetVec2Int(), Val(NARGS))...)
-  promoted_op === Union{} && @show f, NARGS
+  # DEBUG: promoted_op === Union{} && @show f, NARGS
   return promoted_op !== Union{}
 end
 can_turbo(::typeof(vfmaddsub), ::Val{3}) = true


### PR DESCRIPTION
These debug statements were added in https://github.com/JuliaSIMD/LoopVectorization.jl/pull/519. They made CI fail in https://github.com/ranocha/SummationByPartsOperators.jl/pull/241. I think it would be nice to disable them again (or only enable them with a special debug setting?).
It would be nice to get a new release when this is merged.