### PR TITLE
Fixed Expr issue when the ci is a type of GlobalRef 

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -67,7 +67,14 @@ function substitute_broadcast(
       syms[n] = _ciₙ::Symbol
     else
       syms[n] = Symbol('%', n)
-      ciₙ::Expr = _ciₙ::Expr
+      #ciₙ::Expr = _ciₙ::Expr
+      if _ciₙ isa Expr
+          ciₙ = _ciₙ
+      elseif _ciₙ isa GlobalRef
+          ciₙ = Expr(:globalref, _ciₙ.mod, _ciₙ.name)
+      else
+        error("Unexpected type in ci: $(typeof(_ciₙ))")
+      end
       ciₙargs = ciₙ.args
       f = first(ciₙargs)
       if ciₙ.head === :(=)


### PR DESCRIPTION
Error handling if the ci is of type GlobalRef, from which the Expr can be constructed. It also have error handling if the Ci  is a different type. 